### PR TITLE
Small fixes

### DIFF
--- a/pytorch_to_returnn/converter/README.md
+++ b/pytorch_to_returnn/converter/README.md
@@ -46,7 +46,7 @@ The transformation happens on multiple steps,
 and we verify the outputs after each step.
 
 (Note about randomness:
-We reset the PyTorch random seed before each step.
+We reset the PyTorch and numpy random seed before each step.
 In case this is non-deterministic,
 this is ok as long as it stays within our numerical limits.)
 

--- a/pytorch_to_returnn/converter/converter.py
+++ b/pytorch_to_returnn/converter/converter.py
@@ -130,6 +130,7 @@ class Converter:
     """
     print(">>> Running with standard reference imports...")
     torch.manual_seed(42)
+    numpy.random.seed(42)
     with torch.no_grad():
       out_ref = self._model_func(None, torch.from_numpy(self._inputs_np))
       assert isinstance(out_ref, torch.Tensor)
@@ -147,6 +148,7 @@ class Converter:
     """
     print(">>> Running with wrapped imports, wrapping original PyTorch...")
     torch.manual_seed(42)
+    numpy.random.seed(42)
     with torch.no_grad():
       with Naming.make_instance(
             wrap_to_returnn_enabled=False,
@@ -174,6 +176,7 @@ class Converter:
   def _run_torch_returnn_drop_in(self):
     print(">>> Running with wrapped Torch import, wrapping replacement for PyTorch...")
     torch.manual_seed(42)
+    numpy.random.seed(42)
     with tf.compat.v1.Session() as session:
       with Naming.make_instance(
             wrap_to_returnn_enabled=True,

--- a/pytorch_to_returnn/import_wrapper/torch_wrappers/tensor.py
+++ b/pytorch_to_returnn/import_wrapper/torch_wrappers/tensor.py
@@ -21,7 +21,12 @@ class WrappedTorchTensor(torch.Tensor):
   def new(self, *args, **kwargs):
     # For some reason, new() via __torch_function__ behaves different?
     # This is a workaround.
-    return self.new_empty(*args, **kwargs)
+    if args and isinstance(args[0], torch.Tensor):
+      assert len(args) == 1
+      assert args[0].type() == self.type()
+      return args[0]
+    else:
+      return self.new_empty(*args, **kwargs)
 
   @classmethod
   def __torch_function__(cls, func, types, args=(), kwargs=None):

--- a/pytorch_to_returnn/naming/naming.py
+++ b/pytorch_to_returnn/naming/naming.py
@@ -366,7 +366,7 @@ class Naming:
           return
         if not list(mod.module.parameters(recurse=False)):
           continue
-        assert prefix and prefix.endswith(".") and len(namespace.modules) == 1
+        assert (prefix == "" or prefix.endswith(".")) and len(namespace.modules) == 1
         d[prefix[:-1]] = mod.module
         _visited.add(mod.module)
       for name, sub in namespace.childs_by_name.items():

--- a/pytorch_to_returnn/torch/nn/modules/container.py
+++ b/pytorch_to_returnn/torch/nn/modules/container.py
@@ -1,6 +1,7 @@
 
 from typing import Any, Iterable, Iterator, Mapping, Optional, overload, Tuple, TypeVar, Union, Dict
 from collections import OrderedDict
+from collections import abc as container_abcs
 import operator
 from itertools import islice
 from .module import Module

--- a/pytorch_to_returnn/torch/tensor.py
+++ b/pytorch_to_returnn/torch/tensor.py
@@ -131,8 +131,14 @@ class Tensor:
     # use new_zeros here to avoid errors by uninitialized memory
     return self.new_zeros(size, dtype, device, requires_grad)
 
-  def new(self, *size, dtype=None, device=None, requires_grad=False):
-    return self.new_empty(size, dtype, device, requires_grad)
+  def new(self, *args, dtype=None, device=None, requires_grad=False):
+    if args and isinstance(args[0], Tensor):
+      assert len(args) == 1
+      assert args[0].type() == self.type()
+      return args[0]
+    else:
+      shape = args
+      return self.new_empty(shape, dtype, device, requires_grad)
 
   def copy_(self, source: Tensor):
     self._numpy_buffer = source.view(*self._shape).type(self.dtype)._numpy_buffer.copy()

--- a/pytorch_to_returnn/torch/tensor.py
+++ b/pytorch_to_returnn/torch/tensor.py
@@ -248,5 +248,10 @@ class Tensor:
 
 
 class LongTensor(Tensor):
-  def __init__(self, **kwargs):
-    super(LongTensor, self).__init__(dtype="int64", **kwargs)
+  def __init__(self, *args):
+    super(LongTensor, self).__init__(dtype="int64", *args)
+
+
+class FloatTensor(Tensor):
+  def __init__(self, *args):
+    super(FloatTensor, self).__init__(dtype="float32", *args)


### PR DESCRIPTION
These are some really small changes.

- The numpy random seed should be reset before each run just like the PyTorch random seed.
- `tensor.new` behaves different from `tensor.new_empty` when a tensor is passed as argument. I adapted that.
- Fix of small naming problem for the case that the root module contains parameters.
- One import was missing for the code of `ModuleList`.
- Added `FloatTensor` and fixed the args of `LongTensor`.