### PR TITLE
fix and extend tensor initializers

### DIFF
--- a/pytorch_to_returnn/torch/nn/init.py
+++ b/pytorch_to_returnn/torch/nn/init.py
@@ -36,6 +36,10 @@ def ones_(tensor):
   pass
 
 
+def constant_(tensor, value=0):
+  pass
+
+
 def uniform_(tensor, a=0., b=1.):
   pass
 
@@ -53,4 +57,8 @@ def xavier_normal_(tensor: Tensor, gain=1.):
 
 
 def kaiming_uniform_(tensor: Tensor, a=0, mode='fan_in', nonlinearity='leaky_relu'):
+  pass
+
+
+def kaiming_normal_(tensor: Tensor, a=0, mode='fan_in', nonlinearity='leaky_relu'):
   pass

--- a/pytorch_to_returnn/torch/tensor.py
+++ b/pytorch_to_returnn/torch/tensor.py
@@ -140,9 +140,16 @@ class Tensor:
   def normal_(self, mean=0, std=1):
     from .nn.init import normal_
     normal_(self, mean=mean, std=std)
+    return self
+
+  def uniform_(self, a=0, b=1):
+    from .nn.init import uniform_
+    uniform_(self, a=a, b=b)
+    return self
 
   def zero_(self):
     self.fill_(0)
+    return self
 
   def fill_(self, x):
     if not self._shape:  # scalar


### PR DESCRIPTION
Add `kaiming_normal_` and `constant_`.

Also, `torch.Tensor.uniform_()` and related should have a return value, e.g. I encountered a statement 
`self.mask_emb = nn.Parameter(torch.FloatTensor(args.encoder_embed_dim).uniform_())`
which does not work if there is no return value.