### PR TITLE
Reduced printing of numpy arrays

### DIFF
--- a/pytorch_to_returnn/naming/call.py
+++ b/pytorch_to_returnn/naming/call.py
@@ -9,6 +9,7 @@ from . import module as _module
 from . import naming as _naming
 from . import tensor as _tensor
 from . import namespace as _namespace
+from ..pprint import pprint
 
 
 class CallEntry:
@@ -120,7 +121,7 @@ class CallEntry:
           call0 = self.module.calls[0]
           prev_call_name, _ = parent_namespace.name_in_ctx([call0.namespace])
           layer_dict["reuse_params"] = prev_call_name
-      print(f"*** {returnn_net.name}/{layer_name!r} layer dict: {layer_dict}")
+      pprint(layer_dict, prefix=f"*** {returnn_net.name}/{layer_name!r} layer dict: ")
 
       # Now the main construction of the layer itself.
       # Collect also potential new TF update ops (e.g. running statistics).

--- a/pytorch_to_returnn/pprint.py
+++ b/pytorch_to_returnn/pprint.py
@@ -93,7 +93,7 @@ import numpy
 
 def pprint(o: Any, *, file=sys.stdout,
            prefix="", postfix="",
-           line_prefix="", line_postfix="\n") -> None:
+           line_prefix="", line_postfix="\n", numpy_threshold_print_all=10) -> None:
   if "\n" in line_postfix and _type_simplicity_score(o) <= _type_simplicity_limit:
     prefix = f"{line_prefix}{prefix}"
     line_prefix = ""
@@ -166,11 +166,18 @@ def pprint(o: Any, *, file=sys.stdout,
     return
 
   if isinstance(o, numpy.ndarray):
-    _sub_pprint(
-      o.tolist(),
-      prefix=f"{prefix}numpy.array(",
-      postfix=f", dtype=numpy.{o.dtype}){postfix}",
-      inc_indent=False)
+    if o.size <= numpy_threshold_print_all:
+      _sub_pprint(
+        o.tolist(),
+        prefix=f"{prefix}numpy.array(",
+        postfix=f", dtype=numpy.{o.dtype}){postfix}",
+        inc_indent=False)
+    else:
+      _sub_pprint(
+        "[...]",
+        prefix=f"{prefix}numpy.array(",
+        postfix=f", dtype=numpy.{o.dtype}) of shape {o.shape}{postfix}",
+        inc_indent=False)
     return
 
   # fallback


### PR DESCRIPTION
It's maybe personal preference, but I don't like if all values for all numpy arrays are always printed, especially when a lot of `ConstantLayer`s are used. I therefore added a threshold and if a numpy array contains more values, only an abbreviated string is printed.