### PR TITLE
enable forward with kwargs

### DIFF
--- a/pytorch_to_returnn/converter/converter.py
+++ b/pytorch_to_returnn/converter/converter.py
@@ -132,7 +132,7 @@ class Converter:
     torch.manual_seed(42)
     numpy.random.seed(42)
     with torch.no_grad():
-      out_ref = self._model_func(None, torch.from_numpy(self._inputs_np))
+      out_ref = self._model_func(None, torch.from_numpy(self._inputs_np.copy()))
       assert isinstance(out_ref, torch.Tensor)
       out_ref_np = out_ref.cpu().numpy()
     self._out_ref_np = out_ref_np
@@ -154,7 +154,7 @@ class Converter:
             wrap_to_returnn_enabled=False,
             keep_orig_module_io_tensors=self.verify_individual_model_io) as naming:
         wrapped_torch = wrapped_import_torch_traced("torch")
-        out_wrapped = self._model_func(wrapped_import_torch_traced, wrapped_torch.from_numpy(self._inputs_np))
+        out_wrapped = self._model_func(wrapped_import_torch_traced, wrapped_torch.from_numpy(self._inputs_np.copy()))
         assert isinstance(out_wrapped, WrappedTorchTensor)
         out_wrapped_np = out_wrapped.cpu().numpy()
         print(">>>> Module naming hierarchy:")
@@ -184,7 +184,7 @@ class Converter:
             keep_orig_module_io_tensors=True,  # it's only symbolic anyway in TF
             import_params_from_torch_namespace=self._torch_namespace) as naming:
         assert isinstance(naming, Naming)
-        in_returnn = torch_returnn.from_numpy(self._inputs_np)
+        in_returnn = torch_returnn.from_numpy(self._inputs_np.copy())
         assert isinstance(in_returnn, torch_returnn.Tensor)
         x = naming.register_input(in_returnn, Data("data", **self._returnn_in_data_dict))
         out_returnn = self._model_func(wrapped_import_torch_returnn, in_returnn)

--- a/pytorch_to_returnn/naming/call.py
+++ b/pytorch_to_returnn/naming/call.py
@@ -98,7 +98,7 @@ class CallEntry:
       for x in inputs_flat:
         if isinstance(x, Tensor):
           self.namespace.register_input(tensor=naming.tensors[x])
-      res = module.forward(*inputs_args)
+      res = module.forward(*inputs_args, **inputs_kwargs)
       res_flat = nest.flatten(res)
       assert len(res_flat) >= 1
       if self.namespace.returnn_ctx.sub_net_layer:

--- a/pytorch_to_returnn/torch/nn/modules/module.py
+++ b/pytorch_to_returnn/torch/nn/modules/module.py
@@ -397,7 +397,6 @@ class Module:
     return self  # ignore
 
   def __call__(self, *input: Tensor, **kwargs):
-    assert not kwargs  # not implemented yet
     naming = Naming.get_instance()
     with naming.push_module_context(self):
       assert naming.wrap_to_returnn_enabled
@@ -411,7 +410,7 @@ class Module:
         res = call_entry.apply_call()
       return res
 
-  def forward(self, *inputs: Tensor) -> Tensor:
+  def forward(self, *inputs: Tensor, **kwargs) -> Tensor:
     """
     Note:
 

--- a/pytorch_to_returnn/torch/nn/modules/variable.py
+++ b/pytorch_to_returnn/torch/nn/modules/variable.py
@@ -57,6 +57,13 @@ class Constant(Module):
       for i in range(1, value.shape[0]):
         numpy.testing.assert_equal(value[0], value[i])
       value = value[0]  # remove batch axis
+    assert isinstance(value, numpy.ndarray)
+    # Simplify representation in these simple cases.
+    if not value.shape:  # scalar
+      if value.dtype == "int32":
+        value = int(value)
+      elif value.dtype == "float32":
+        value = float(value)
     d = {"class": "constant", "value": value}
     if batch_axis is not None:
       d["with_batch_dim"] = True

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -509,7 +509,8 @@ def test_forward_with_kwargs():
         super(MyModel, self).__init__()
         self.bias = bias
 
-      def forward(self, x, add_bias=False):
+      def forward(self, x, *, add_bias=None):
+        assert isinstance(add_bias, bool)
         if add_bias:
           x += self.bias
         return x


### PR DESCRIPTION
Currently, `Module.forward` is not supported when using kwargs as shown in the test cast. This draft PR is meant to fix this.