### PR TITLE
add more tensor operations

### DIFF
--- a/pytorch_to_returnn/torch/nn/functional.py
+++ b/pytorch_to_returnn/torch/nn/functional.py
@@ -329,6 +329,10 @@ def logsigmoid(input: Tensor):
   return modules.LogSigmoid().as_returnn_torch_functional()(input)
 
 
+def pow(input: Tensor, exponent: float):
+  return modules.Power(exponent=exponent).as_returnn_torch_functional()(input)
+
+
 def normalize(input: Tensor, p=2, dim=1, eps=1e-12) -> Tensor:
   norm_ = modules.Norm(p=p, axes=[dim], keepdims=True)(input)
   norm_f = modules.Reciprocal(eps=eps)(norm_)

--- a/pytorch_to_returnn/torch/nn/modules/activation.py
+++ b/pytorch_to_returnn/torch/nn/modules/activation.py
@@ -41,6 +41,8 @@ class LogSigmoid(_ActivationReturnn):
 
 
 class Power(Module):
+  is_original_torch_module = False
+
   def __init__(self, exponent: float) -> None:
     super(Power, self).__init__()
     self.exponent = exponent

--- a/pytorch_to_returnn/torch/nn/modules/activation.py
+++ b/pytorch_to_returnn/torch/nn/modules/activation.py
@@ -40,6 +40,17 @@ class LogSigmoid(_ActivationReturnn):
   func_name = "log_sigmoid"
 
 
+class Power(Module):
+  def __init__(self, exponent: float) -> None:
+    super(Power, self).__init__()
+    self.exponent = exponent
+
+  def create_returnn_layer_dict(self, input: Tensor) -> Dict[str, Any]:
+    return {
+      "class": "eval", "eval": f"tf.math.pow(source(0), {self.exponent})",
+      "from": self._get_input_layer_name(input)}
+
+
 class LeakyReLU(Module):
   def __init__(self, negative_slope: float = 1e-2, inplace: bool = False) -> None:
     super(LeakyReLU, self).__init__()

--- a/pytorch_to_returnn/torch/tensor.py
+++ b/pytorch_to_returnn/torch/tensor.py
@@ -88,6 +88,12 @@ class Tensor:
   def contiguous(self):
     return self  # ignore
 
+  def clone(self):
+    return self  # ignore
+
+  def device(self):
+    return None  # ignore
+
   def flatten(self):
     from .nn.functional import flatten
     return flatten(self)
@@ -196,6 +202,10 @@ class Tensor:
   def sigmoid(self):
     from .nn.functional import sigmoid
     return sigmoid(self)
+
+  def pow(self, exponent):
+    from .nn.functional import pow
+    return pow(self, exponent)
 
   def chunk(self, chunks: int, dim: int = 0) -> List[Tensor]:
     from .nn.functional import chunk

--- a/pytorch_to_returnn/torch/tensor.py
+++ b/pytorch_to_returnn/torch/tensor.py
@@ -203,7 +203,7 @@ class Tensor:
     from .nn.functional import sigmoid
     return sigmoid(self)
 
-  def pow(self, exponent):
+  def pow(self, exponent: float):
     from .nn.functional import pow
     return pow(self, exponent)
 


### PR DESCRIPTION
Specifically, `tensor.clone` and `tensor.device` which are ignored here as well as `tensor.pow`. Not sure if there is a more elegant way for `pow` than the `EvalLayer` but this seems pretty straight-forward.