### PR TITLE
subnetwork problem in group norm

### DIFF
--- a/pytorch_to_returnn/naming/call.py
+++ b/pytorch_to_returnn/naming/call.py
@@ -168,7 +168,7 @@ class CallEntry:
 
       if naming.import_params_from_torch_namespace and layer:
         if not layer_abs_repr_name.startswith("."):  # temp layer
-          if module.is_original_torch_module:
+          if module.is_original_torch_module and not module.has_torch_forward():
             if list(module.parameters(recurse=False)):
               # Need some way to get a unique name, to get the corresponding module from previous Torch run.
               # We can use get_module_abs_name, to get the attrib chain,

--- a/pytorch_to_returnn/naming/namespace.py
+++ b/pytorch_to_returnn/naming/namespace.py
@@ -285,9 +285,10 @@ class RegisteredName:
       child.dump(prefix=f"{prefix}  ")
 
   def dump_as_returnn_layer_dict(self) -> Dict[str, Any]:
-    if self.calls and not self.calls[0].module.module.has_torch_forward():
+    if not self.is_subnet:
       assert len(self.calls) == 1
       call = self.calls[0]
+      assert call.returnn_layer_dict
       return call.returnn_layer_dict
     # Subnetwork
     inputs = []

--- a/pytorch_to_returnn/torch/nn/modules/module.py
+++ b/pytorch_to_returnn/torch/nn/modules/module.py
@@ -442,6 +442,7 @@ class Module:
       orig_import_params_torch_to_returnn(layer=sub_layer, torch_module=torch_module)
 
     setattr(self, "import_params_torch_to_returnn", import_params_torch_to_returnn)
+    setattr(self, "has_torch_forward", lambda: False)
 
     class _WrappedBaseClass(Module):
       is_original_torch_module = False

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -370,6 +370,42 @@ def test_fp32_group_norm():
     verify_torch_and_convert_to_returnn(model_func, inputs=x)
 
 
+def test_fp32_group_norm_subnetwork():
+  n_batch, n_time = 3, 17
+  for num_groups, num_channels in [(1, 5), (5, 5)]:
+
+    def model_func(wrapped_import, inputs: torch.Tensor):
+      if typing.TYPE_CHECKING or not wrapped_import:
+        import torch
+        import torch.nn.functional as F
+      else:
+        torch = wrapped_import("torch")
+        F = wrapped_import("torch.nn.functional")
+
+      # copy of Fp32GroupNorm from fairseq
+      class Fp32GroupNorm(torch.nn.GroupNorm):
+        def __init__(self, *args, **kwargs):
+          super().__init__(*args, **kwargs)
+
+        def forward(self, input):
+          output = F.group_norm(
+            input.float(),
+            self.num_groups,
+            self.weight.float() if self.weight is not None else None,
+            self.bias.float() if self.bias is not None else None,
+            self.eps)
+          return output.type_as(input)
+
+      model = torch.nn.Sequential(Fp32GroupNorm(num_groups, num_channels))
+      out = model(inputs)
+      return out
+
+    print(f"test for num_groups={num_groups}, num_channels={num_channels}")
+    rnd = numpy.random.RandomState(42)
+    x = rnd.normal(0., 1., (n_batch, num_channels, n_time)).astype("float32")
+    verify_torch_and_convert_to_returnn(model_func, inputs=x)
+
+
 def test_unsqueeze():
   n_in, n_out = 11, 13
   n_batch, n_time = 3, 7


### PR DESCRIPTION
I slightly modified the `Fp32GroupNorm` test case to reproduce the problem that I mentioned earlier in #18. If `Fp32GroupNorm` is wrapped inside a `Sequential`, the layer that is input to `GroupNorm.import_params_torch_to_returnn` will be a `SubnetworkLayer`. Do you have any ideas on this?