### PR TITLE
Add torch.cat for the case that concatenation happens in the feature dim

### DIFF
--- a/pytorch_to_returnn/torch/nn/functional.py
+++ b/pytorch_to_returnn/torch/nn/functional.py
@@ -11,6 +11,7 @@ from typing import Optional, Union, List, Tuple, Dict, TypeVar, Sequence
 from . import modules
 from ..tensor import Tensor
 from .._C import Size, dtype as _dtype
+from ...naming import Naming
 
 
 _number = Union[int, float, numpy.ndarray, numpy.number]
@@ -45,6 +46,14 @@ def cast(input: Union[_T, Tensor, _number], dtype: Union[str, _dtype]) -> Union[
   if dtype == get_dtype(input):
     return input
   return modules.Cast(dtype=dtype)(input)
+
+def cat(tensors, dim=0):
+  from .modules.operator import Copy
+  naming = Naming.get_instance()
+  for tensor in tensors:
+    returnn_data = naming.tensors[tensor].returnn_data
+    assert returnn_data.get_axis_from_description(dim) == returnn_data.feature_dim_axis, "Concatenation in dimensions other than the feature dimension is currently not supported."
+  return Copy().as_returnn_torch_functional()(*tensors)
 
 
 def get_dtype(tensor: Union[Tensor, _number]) -> _dtype:

--- a/pytorch_to_returnn/torch/nn/functional.py
+++ b/pytorch_to_returnn/torch/nn/functional.py
@@ -48,12 +48,8 @@ def cast(input: Union[_T, Tensor, _number], dtype: Union[str, _dtype]) -> Union[
   return modules.Cast(dtype=dtype)(input)
 
 def cat(tensors, dim=0):
-  from .modules.operator import Copy
-  naming = Naming.get_instance()
-  for tensor in tensors:
-    returnn_data = naming.tensors[tensor].returnn_data
-    assert returnn_data.get_axis_from_description(dim) == returnn_data.feature_dim_axis, "Concatenation in dimensions other than the feature dimension is currently not supported."
-  return Copy().as_returnn_torch_functional()(*tensors)
+  from .modules.operator import Cat
+  return Cat(dim).as_returnn_torch_functional()(*tensors)
 
 
 def get_dtype(tensor: Union[Tensor, _number]) -> _dtype:

--- a/pytorch_to_returnn/torch/nn/modules/operator.py
+++ b/pytorch_to_returnn/torch/nn/modules/operator.py
@@ -10,13 +10,8 @@ from ....naming import Naming, TensorEntry
 class Copy(Module):
   is_original_torch_module = False
 
-  def create_returnn_layer_dict(self, input: Tensor) -> Dict[str, Any]:
-    return {"class": "copy", "from": self._get_input_layer_name(input)}
-
-  def make_output_tensor_from_returnn(self, inputs_flat: List[Tensor], layer: LayerBase) -> Tensor:
-    assert len(inputs_flat) == 1
-    return inputs_flat[0]
-
+  def create_returnn_layer_dict(self, *inputs: Tensor) -> Dict[str, Any]:
+    return {"class": "copy", "from": [self._get_input_layer_name(input) for input in inputs]}
 
 class GetSublayer(Module):
   is_original_torch_module = False

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -51,6 +51,19 @@ def test_linear_multiple_steps():
       "shape": (None, n_in * n_steps), "batch_dim_axis": 0, "time_dim_axis": 1, "feature_dim_axis": 2})
 
 
+def test_cat():
+
+  def model_func(wrapped_import, inputs: torch.Tensor):
+      if wrapped_import:
+        torch = wrapped_import("torch")
+      else:
+        import torch
+      return torch.cat((inputs, inputs), dim=-1)
+
+  rnd = numpy.random.RandomState(42)
+  x = rnd.normal(0., 1., (3,3)).astype("float32")
+  verify_torch_and_convert_to_returnn(model_func, inputs=x)
+
 def test_conv():
   n_in, n_out = 11, 13
   n_batch, n_time = 3, 7


### PR DESCRIPTION
In case concatenation of tensors happens in the feature dimension we can take advantage of the fact that the RETURNN copy layer concatenates it's inputs in the feature dimension.