### PR TITLE
allow more general reshapes

### DIFF
--- a/pytorch_to_returnn/torch/nn/functional.py
+++ b/pytorch_to_returnn/torch/nn/functional.py
@@ -163,10 +163,22 @@ def reshape(input: Tensor, shape: Tuple[int, ...]) -> Tensor:
         assert shape[axis2] % n == 0 and n < shape[axis2]
         n *= input.shape[a]
         a += 1
-      assert n == shape[axis2]
-      input = modules.Flatten(start_dim=axis1, end_dim=a - 1).as_returnn_torch_functional()(input)
-      assert input.shape[axis1] == shape[axis2]
-      continue
+      if n == shape[axis2]:
+        input = modules.Flatten(start_dim=axis1, end_dim=a - 1).as_returnn_torch_functional()(input)
+        assert input.shape[axis1] == shape[axis2]
+        continue
+      elif shape[axis2] % input.shape[axis1] == 0:
+        split_factor = shape[axis2] // input.shape[axis1]
+        assert input.shape[axis1 + 1] == shape[axis2 + 1] * split_factor
+        # something like (..., a, b*c,...) -> (..., a*b, c,...)
+        unflattened_size = (split_factor, shape[axis2 + 1])
+        input = modules.Unflatten(dim=axis1 + 1, unflattened_size=unflattened_size).as_returnn_torch_functional()(input)
+        input = modules.Flatten(start_dim=axis1, end_dim=axis1 + 1).as_returnn_torch_functional()(input)
+        assert input.shape[axis1] == shape[axis2]
+        axis1 += 1
+        axis2 += 1
+        assert input.shape[axis1] == shape[axis2]
+        continue
     elif input.shape[axis1] > shape[axis2]:
       n = 1
       a = axis2
@@ -174,10 +186,23 @@ def reshape(input: Tensor, shape: Tuple[int, ...]) -> Tensor:
         assert input.shape[axis1] % n == 0 and n < input.shape[axis1]
         n *= shape[a]
         a += 1
-      assert n == input.shape[axis1]
-      input = modules.Unflatten(dim=axis1, unflattened_size=tuple(shape[axis2:a])).as_returnn_torch_functional()(input)
-      assert input.shape[axis1] == shape[axis2]
-      continue
+      if n == input.shape[axis1]:
+        unflattened_size = tuple(shape[axis2:a])
+        input = modules.Unflatten(dim=axis1, unflattened_size=unflattened_size).as_returnn_torch_functional()(input)
+        assert input.shape[axis1] == shape[axis2]
+        continue
+      elif input.shape[axis1] % shape[axis2] == 0:
+        split_factor = input.shape[axis1] // shape[axis2]
+        assert input.shape[axis1 + 1] * split_factor == shape[axis2 + 1]
+        # something like (..., a*b, c,...) -> (..., a, b*c,...)
+        unflattened_size = (shape[axis2], split_factor)
+        input = modules.Unflatten(dim=axis1, unflattened_size=unflattened_size).as_returnn_torch_functional()(input)
+        assert input.shape[axis1] == shape[axis2]
+        axis1 += 1
+        axis2 += 1
+        input = modules.Flatten(start_dim=axis1, end_dim=axis1 + 1).as_returnn_torch_functional()(input)
+        assert input.shape[axis1] == shape[axis2]
+        continue
     else:
       assert False  # cannot happen
   assert axis1 == axis2

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -224,22 +224,21 @@ def test_t():
 
 
 def test_reshape():
-  n_batch, n_feature, n_time = 3, 8, 5
+  n_batch, n_time, n_feature_1, n_feature_2 = 3, 5, 8, 6
 
   def model_func_1(wrapped_import, inputs: torch.Tensor):
     # test case (..., a*b, c,...) -> (..., a, b*c,...)
-    return inputs.view(n_batch, n_feature // 2, n_time * 2)
+    return inputs.view(n_batch, n_time, n_feature_1 // 2, n_feature_2 * 2)
 
   def model_func_2(wrapped_import, inputs: torch.Tensor):
     # test case (..., a, b*c,...) -> (..., a*b, c,...)
-    return inputs.view(n_batch, n_time * 2, n_feature // 2)
+    return inputs.view(n_batch, n_time, n_feature_1 * 2, n_feature_2 // 2)
 
   rnd = numpy.random.RandomState(42)
-  x = rnd.normal(0., 1., (n_batch, n_feature, n_time)).astype("float32")
-  verify_torch_and_convert_to_returnn(model_func_1, inputs=x)
-  x = rnd.normal(0., 1., (n_batch, n_time, n_feature)).astype("float32")
-  verify_torch_and_convert_to_returnn(model_func_2, inputs=x, inputs_data_kwargs={
-      "shape": (None, n_feature), "batch_dim_axis": 0, "time_dim_axis": 1, "feature_dim_axis": 2})
+  x = rnd.normal(0., 1., (n_batch, n_time, n_feature_1, n_feature_2)).astype("float32")
+  for model_func in [model_func_1, model_func_2]:
+    verify_torch_and_convert_to_returnn(model_func, inputs=x, inputs_data_kwargs={
+        "shape": (None, n_feature_1, n_feature_2), "batch_dim_axis": 0, "time_dim_axis": 1, "feature_dim_axis": 2})
 
 
 def test_functional_conv():

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -223,6 +223,25 @@ def test_t():
   verify_torch_and_convert_to_returnn(model_func, inputs=x)
 
 
+def test_reshape():
+  n_batch, n_feature, n_time = 3, 8, 5
+
+  def model_func_1(wrapped_import, inputs: torch.Tensor):
+    # test case (..., a*b, c,...) -> (..., a, b*c,...)
+    return inputs.view(n_batch, n_feature // 2, n_time * 2)
+
+  def model_func_2(wrapped_import, inputs: torch.Tensor):
+    # test case (..., a, b*c,...) -> (..., a*b, c,...)
+    return inputs.view(n_batch, n_time * 2, n_feature // 2)
+
+  rnd = numpy.random.RandomState(42)
+  x = rnd.normal(0., 1., (n_batch, n_feature, n_time)).astype("float32")
+  verify_torch_and_convert_to_returnn(model_func_1, inputs=x)
+  x = rnd.normal(0., 1., (n_batch, n_time, n_feature)).astype("float32")
+  verify_torch_and_convert_to_returnn(model_func_2, inputs=x, inputs_data_kwargs={
+      "shape": (None, n_feature), "batch_dim_axis": 0, "time_dim_axis": 1, "feature_dim_axis": 2})
+
+
 def test_functional_conv():
   n_in, n_out = 11, 13
   n_batch, n_time = 3, 7


### PR DESCRIPTION
Generalize `reshape` to allow reshapes of `(..., a*b, c,...) -> (..., a, b*c,...)` or `(..., a, b*c,...) -> (..., a*b, c,...)`.