### PR TITLE
fix matmul

### DIFF
--- a/pytorch_to_returnn/torch/nn/modules/linear.py
+++ b/pytorch_to_returnn/torch/nn/modules/linear.py
@@ -1,13 +1,14 @@
 
 from __future__ import annotations
 import math
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Tuple, List
 import tensorflow as tf
-from returnn.tf.layers.basic import LinearLayer
+from returnn.tf.layers.basic import LayerBase, LinearLayer
 from .module import Module
 from ..parameter import Parameter
 from ...tensor import Tensor
 from .. import init
+from ....naming import Naming, TensorEntry
 
 
 class Identity(Module):
@@ -67,6 +68,32 @@ class Matmul(Module):
   """
   is_original_torch_module = False
 
+  def _get_output_shape_from_returnn(self, inputs_flat: List[Tensor], layer: LayerBase
+                                     ) -> Tuple[Tuple[int, ...], Dict[int, int]]:
+    assert len(inputs_flat) == 2
+    input1, input2 = inputs_flat
+    assert all(isinstance(input_, Tensor) for input_ in [input1, input2])
+    assert all(len(input_.shape) >= 2 for input_ in [input1, input2]), "not implemented otherwise"
+
+    max_len = max(len(input1.shape), len(input2.shape))
+    shape1 = [None] * (max_len - len(input1.shape)) + list(input1.shape)
+    shape2 = [None] * (max_len - len(input2.shape)) + list(input2.shape)
+    shape = []
+    for ax in range(max_len - 2):
+      if shape1[ax] == shape2[ax]:
+        shape.append(shape1[ax])
+      elif isinstance(shape1[ax], int) and shape1[ax] > 1:
+        assert shape2[ax] in [1, None], f"dimensions are not broadcastable: {input1.shape} vs. {input2.shape}"
+        shape.append(shape1[ax])
+      elif isinstance(shape2[ax], int) and shape2[ax] > 1:
+        assert shape1[ax] in [1, None], f"dimensions are not broadcastable: {input1.shape} vs. {input2.shape}"
+        shape.append(shape2[ax])
+
+    shape += [shape1[-2], shape2[-1]]
+    shape = tuple(shape)
+    returnn_axis_from_torch_axis = {i: i for i in range(len(shape))}
+    return shape, returnn_axis_from_torch_axis
+
   def create_returnn_layer_dict(self, *inputs: Tensor, **kwargs) -> Dict[str, Any]:
     sources = [self._get_input_layer_name(source) for source in inputs]
     assert len(sources) == 2
@@ -84,12 +111,12 @@ class Matmul(Module):
     for ax in range(-3, -max_len - 1, -1):
       if isinstance(shape1[ax], int) and shape1[ax] > 1:
         if shape2[ax] in [1, None]:
-          var1.append(self._get_input_axis_to_returnn(inputs[0], ax))
+          var1.insert(0, self._get_input_axis_to_returnn(inputs[0], ax))
         else:
           assert shape1[ax] == shape2[ax], f"dimensions are not broadcastable: {inputs[0].shape} vs. {inputs[1].shape}"
       if isinstance(shape2[ax], int) and shape2[ax] > 1:
         if shape1[ax] in [1, None]:
-          var2.append(self._get_input_axis_to_returnn(inputs[1], ax))
+          var2.insert(0, self._get_input_axis_to_returnn(inputs[1], ax))
         else:
           assert shape1[ax] == shape2[ax], f"dimensions are not broadcastable: {inputs[0].shape} vs. {inputs[1].shape}"
 


### PR DESCRIPTION
I added a test for the case of multiple shared remaining axes which failed. To fix it, I added `Matmul._get_output_shape_from_returnn`. Additionally, in `Matmul.create_returnn_layer_dict`, `var1` and `var2` should be created by inserting at the beginning of the list, not by appending. Otherwise, the output order in returnn is reversed.