### PR TITLE
fix for spatial axes with same dim tag

### DIFF
--- a/pytorch_to_returnn/naming/tensor.py
+++ b/pytorch_to_returnn/naming/tensor.py
@@ -108,7 +108,7 @@ class TensorEntry:
       if len(axes_with_same_dim_tag) == 1:
         return f"stag:{dim_tag.description}"
       else:
-        return f"stag-single:{axis - ndim}:{dim_tag.description}"
+        return f"stag-single:{axes_with_same_dim_tag.index(axis) - len(axes_with_same_dim_tag)}:{dim_tag.description}"
     static_axes = self.returnn_data.get_static_axes()
     if axis in static_axes:
       return f"static:{static_axes.index(axis)}"

--- a/pytorch_to_returnn/naming/tensor.py
+++ b/pytorch_to_returnn/naming/tensor.py
@@ -104,7 +104,11 @@ class TensorEntry:
     dim_tag = self.returnn_data.get_dim_tag(axis)
     assert dim_tag.kind == DimensionTag.Types.Spatial
     if dim_tag.dyn_size is not None:
-      return f"stag:{dim_tag.description}"
+      axes_with_same_dim_tag = [ax for ax in range(ndim) if dim_tag == self.returnn_data.get_dim_tag(ax)]
+      if len(axes_with_same_dim_tag) == 1:
+        return f"stag:{dim_tag.description}"
+      else:
+        return f"stag-single:{axis - ndim}:{dim_tag.description}"
     static_axes = self.returnn_data.get_static_axes()
     if axis in static_axes:
       return f"static:{static_axes.index(axis)}"

--- a/pytorch_to_returnn/torch/nn/modules/module.py
+++ b/pytorch_to_returnn/torch/nn/modules/module.py
@@ -759,7 +759,7 @@ class Module:
 
     def _get_unique_spatial_dim_tag_name(data, axis):
       dim_tag = data.get_dim_tag(axis)
-      idx = data.get_spatial_batch_axes().index(axis)
+      idx = data.get_axes_by_tag_name(dim_tag.description).index(axis)
       return f"stag-single:{idx}:{dim_tag.description}"
 
     out_returnn_axis_to_torch_axis = {}

--- a/pytorch_to_returnn/torch/nn/modules/module.py
+++ b/pytorch_to_returnn/torch/nn/modules/module.py
@@ -758,6 +758,9 @@ class Module:
     # However, this is simpler, and also more consistent with get_returnn_axis_description.
 
     def _get_spatial_dim_tag_and_single_index(data: Data, axis: int) -> Tuple[DimensionTag, int]:
+      """
+      :return: (RETURNN dim tag, spatial dim tag index (for stag-single))
+      """
       dim_tag_ = data.get_dim_tag(axis)
       idx_ = data.get_axes_by_tag_name(dim_tag_.description).index(axis)
       return dim_tag_, idx_
@@ -766,8 +769,8 @@ class Module:
     # Torch would maybe have operated on [B,D_in,T_in] input, and produce [B,D_out,T_out] output.
     naming = Naming.get_instance()
     batch_size = None
-    # RETURNN dim tag, spatial dim tag index (for stag-single) -> in spatial idx, Torch dim
-    dyn_size_dim_tag_to_spatial_idx_and_torch_dim = OrderedDict()
+    # dim_tag_ext -> in spatial idx, Torch dim where dim_tag_ext is from _get_spatial_dim_tag_and_single_index
+    dyn_size_dim_tag_ext_to_spatial_idx_and_torch_dim = OrderedDict()
     for input in inputs_flat:
       if not isinstance(input, Tensor):
         continue
@@ -779,12 +782,12 @@ class Module:
       if x.returnn_data.have_batch_axis():
         batch_size = input.shape[x.returnn_axis_from_torch_axis[x.returnn_data.batch_dim_axis]]
       for i in x.returnn_data.get_dynamic_axes():
-        dim_tag, idx = _get_spatial_dim_tag_and_single_index(x.returnn_data, i)
+        dim_tag_ext = _get_spatial_dim_tag_and_single_index(x.returnn_data, i)
         assert i in x.returnn_data.get_spatial_batch_axes()
         spatial_idx = x.returnn_data.get_spatial_batch_axes().index(i)
         torch_dim = input.shape[x.returnn_axis_from_torch_axis[i]]
-        if (dim_tag, idx) not in dyn_size_dim_tag_to_spatial_idx_and_torch_dim:
-          dyn_size_dim_tag_to_spatial_idx_and_torch_dim[(dim_tag, idx)] = (spatial_idx, torch_dim)
+        if dim_tag_ext not in dyn_size_dim_tag_ext_to_spatial_idx_and_torch_dim:
+          dyn_size_dim_tag_ext_to_spatial_idx_and_torch_dim[dim_tag_ext] = (spatial_idx, torch_dim)
 
       # Find mapping to layer_output_shape_meta.
       mapping_out_to_in = {}
@@ -802,9 +805,9 @@ class Module:
             mapping_out_to_in[out_axis] = None  # new axis
           continue
         if out_axis in layer.output.get_dynamic_axes():
-          dim_tag, idx = _get_spatial_dim_tag_and_single_index(layer.output, out_axis)
-          if (dim_tag, idx) in dyn_size_dim_tag_to_spatial_idx_and_torch_dim:
-            in_spatial_idx, _ = dyn_size_dim_tag_to_spatial_idx_and_torch_dim[(dim_tag, idx)]
+          dim_tag_ext = _get_spatial_dim_tag_and_single_index(layer.output, out_axis)
+          if dim_tag_ext in dyn_size_dim_tag_ext_to_spatial_idx_and_torch_dim:
+            in_spatial_idx, _ = dyn_size_dim_tag_ext_to_spatial_idx_and_torch_dim[dim_tag_ext]
             mapping_out_to_in[out_axis] = x.returnn_data.get_spatial_batch_axes()[in_spatial_idx]
             continue
         assert out_axis in layer.output.get_spatial_batch_axes()
@@ -850,11 +853,11 @@ class Module:
       assert batch_size is not None
       out_shape[layer.output.batch_dim_axis] = batch_size
     if layer.output.get_dynamic_axes():
-      assert dyn_size_dim_tag_to_spatial_idx_and_torch_dim
+      assert dyn_size_dim_tag_ext_to_spatial_idx_and_torch_dim
       for i in layer.output.get_dynamic_axes():
-        dim_tag, idx = _get_spatial_dim_tag_and_single_index(layer.output, i)
-        if (dim_tag, idx) in dyn_size_dim_tag_to_spatial_idx_and_torch_dim:
-          in_spatial_idx, out_shape[i] = dyn_size_dim_tag_to_spatial_idx_and_torch_dim[(dim_tag, idx)]
+        dim_tag_ext = _get_spatial_dim_tag_and_single_index(layer.output, i)
+        if dim_tag_ext in dyn_size_dim_tag_ext_to_spatial_idx_and_torch_dim:
+          in_spatial_idx, out_shape[i] = dyn_size_dim_tag_ext_to_spatial_idx_and_torch_dim[dim_tag_ext]
           if i in rem_returnn_axes:
             out_spatial_idx = rem_returnn_axes_.index(i)
             if in_spatial_idx != out_spatial_idx:
@@ -863,9 +866,9 @@ class Module:
               rem_torch_axes.remove(rem_torch_axes_[in_spatial_idx])
         else:
           # Assume same order.
-          assert len(layer.output.get_dynamic_axes()) == len(dyn_size_dim_tag_to_spatial_idx_and_torch_dim)
+          assert len(layer.output.get_dynamic_axes()) == len(dyn_size_dim_tag_ext_to_spatial_idx_and_torch_dim)
           out_shape[i] = (
-            list(dyn_size_dim_tag_to_spatial_idx_and_torch_dim.values())[layer.output.get_dynamic_axes().index(i)][1])
+            list(dyn_size_dim_tag_ext_to_spatial_idx_and_torch_dim.values())[layer.output.get_dynamic_axes().index(i)][1])
     assert all(d for d in out_shape)
 
     for i, j in zip(sorted(rem_returnn_axes), sorted(rem_torch_axes)):

--- a/pytorch_to_returnn/torch/nn/modules/module.py
+++ b/pytorch_to_returnn/torch/nn/modules/module.py
@@ -773,7 +773,7 @@ class Module:
       if x.returnn_data.have_batch_axis():
         batch_size = input.shape[x.returnn_axis_from_torch_axis[x.returnn_data.batch_dim_axis]]
       for i in x.returnn_data.get_dynamic_axes():
-        dim_tag = x.returnn_data.get_dim_tag(i)
+        dim_tag = x.returnn_data.get_dim_tag(i, unique_spatial_dims=True).description
         assert i in x.returnn_data.get_spatial_batch_axes()
         spatial_idx = x.returnn_data.get_spatial_batch_axes().index(i)
         torch_dim = input.shape[x.returnn_axis_from_torch_axis[i]]
@@ -796,7 +796,7 @@ class Module:
             mapping_out_to_in[out_axis] = None  # new axis
           continue
         if out_axis in layer.output.get_dynamic_axes():
-          dim_tag = layer.output.get_dim_tag(out_axis)
+          dim_tag = layer.output.get_dim_tag(out_axis, unique_spatial_dims=True).description
           if dim_tag in dyn_size_dim_tag_to_spatial_idx_and_torch_dim:
             in_spatial_idx, _ = dyn_size_dim_tag_to_spatial_idx_and_torch_dim[dim_tag]
             mapping_out_to_in[out_axis] = x.returnn_data.get_spatial_batch_axes()[in_spatial_idx]
@@ -846,7 +846,7 @@ class Module:
     if layer.output.get_dynamic_axes():
       assert dyn_size_dim_tag_to_spatial_idx_and_torch_dim
       for i in layer.output.get_dynamic_axes():
-        dim_tag = layer.output.get_dim_tag(i)
+        dim_tag = layer.output.get_dim_tag(i, unique_spatial_dims=True).description
         if dim_tag in dyn_size_dim_tag_to_spatial_idx_and_torch_dim:
           in_spatial_idx, out_shape[i] = dyn_size_dim_tag_to_spatial_idx_and_torch_dim[dim_tag]
           if i in rem_returnn_axes:

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -219,6 +219,27 @@ def test_matmul_shared_remaining_axes():
       "shape": (n_1, None, n_2), "batch_dim_axis": 0, "time_dim_axis": 2, "feature_dim_axis": 3})
 
 
+def test_spatial_axes_with_same_tag():
+  n_1, n_2 = 2, 4
+  n_batch, n_time = 3, 7
+
+  def model_func(wrapped_import, inputs: torch.Tensor):
+    if typing.TYPE_CHECKING or not wrapped_import:
+      import torch
+      import torch.nn.functional as F
+    else:
+      torch = wrapped_import("torch")
+      F = wrapped_import("torch.nn.functional")
+    x = torch.matmul(inputs, inputs.transpose(2, 3))
+    x = F.softmax(x, dim=-1)
+    return x
+
+  rnd = numpy.random.RandomState(42)
+  x = rnd.normal(0., 1., (n_batch, n_1, n_time, n_2)).astype("float32")
+  verify_torch_and_convert_to_returnn(model_func, inputs=x, inputs_data_kwargs={
+      "shape": (n_1, None, n_2), "batch_dim_axis": 0, "time_dim_axis": 2, "feature_dim_axis": 3})
+
+
 def test_bmm():
   n_in, n_out = 11, 13
   n_batch, n_time = 3, 5


### PR DESCRIPTION
Having tensors where multiple axes have the same dim tag lead to problems in `_get_input_axis_to_returnn` as well as when creating `out_returnn_axis_to_torch_axis` in `_base_get_output_shape_from_returnn`. Using the new dim tag format `stag-single:<idx>:<name>` for spatial axes in returnn (see https://github.com/rwth-i6/returnn/pull/490), we can circumvent this.