### PR TITLE
fix for merge dims

### DIFF
--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -260,29 +260,43 @@ def test_t():
   verify_torch_and_convert_to_returnn(model_func, inputs=x)
 
 
-def test_reshape():
+def test_reshape_ab_c_to_a_bc():
   n_batch, n_time, n_feature_1, n_feature_2 = 3, 5, 8, 6
 
-  def model_func_1(wrapped_import, inputs: torch.Tensor):
+  def model_func(wrapped_import, inputs: torch.Tensor):
     # test case (..., a*b, c,...) -> (..., a, b*c,...)
     return inputs.view(n_batch, n_time, n_feature_1 // 2, n_feature_2 * 2)
 
-  def model_func_2(wrapped_import, inputs: torch.Tensor):
+  rnd = numpy.random.RandomState(42)
+  x = rnd.normal(0., 1., (n_batch, n_time, n_feature_1, n_feature_2)).astype("float32")
+  verify_torch_and_convert_to_returnn(model_func, inputs=x, inputs_data_kwargs={
+      "shape": (None, n_feature_1, n_feature_2), "batch_dim_axis": 0, "time_dim_axis": 1, "feature_dim_axis": 2})
+
+
+def test_reshape_a_bc_to_ab_c():
+  n_batch, n_time, n_feature_1, n_feature_2 = 3, 5, 8, 6
+
+  def model_func(wrapped_import, inputs: torch.Tensor):
     # test case (..., a, b*c,...) -> (..., a*b, c,...)
     return inputs.view(n_batch, n_time, n_feature_1 * 2, n_feature_2 // 2)
 
-  def model_func_3(wrapped_import, inputs: torch.Tensor):
+  rnd = numpy.random.RandomState(42)
+  x = rnd.normal(0., 1., (n_batch, n_time, n_feature_1, n_feature_2)).astype("float32")
+  verify_torch_and_convert_to_returnn(model_func, inputs=x, inputs_data_kwargs={
+      "shape": (None, n_feature_1, n_feature_2), "batch_dim_axis": 0, "time_dim_axis": 1, "feature_dim_axis": 2})
+
+
+def test_reshape_a_b_F_to_b_aF():
+  n_batch, n_time, n_feature_1, n_feature_2 = 3, 5, 8, 6
+
+  def model_func(wrapped_import, inputs: torch.Tensor):
     # test case (..., a, b, F,...) -> (..., b, a*F,...)
     inputs = inputs.transpose(1, 2).contiguous()
     return inputs.view(n_batch, n_time, n_feature_1 * n_feature_2)
 
   rnd = numpy.random.RandomState(42)
-  x = rnd.normal(0., 1., (n_batch, n_time, n_feature_1, n_feature_2)).astype("float32")
-  for model_func in [model_func_1, model_func_2]:
-    verify_torch_and_convert_to_returnn(model_func, inputs=x, inputs_data_kwargs={
-        "shape": (None, n_feature_1, n_feature_2), "batch_dim_axis": 0, "time_dim_axis": 1, "feature_dim_axis": 2})
   x = rnd.normal(0., 1., (n_batch, n_feature_1, n_time, n_feature_2)).astype("float32")
-  verify_torch_and_convert_to_returnn(model_func_3, inputs=x, inputs_data_kwargs={
+  verify_torch_and_convert_to_returnn(model_func, inputs=x, inputs_data_kwargs={
       "shape": (n_feature_1, None, n_feature_2), "batch_dim_axis": 0, "time_dim_axis": 2, "feature_dim_axis": 3})
 
 

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -271,11 +271,19 @@ def test_reshape():
     # test case (..., a, b*c,...) -> (..., a*b, c,...)
     return inputs.view(n_batch, n_time, n_feature_1 * 2, n_feature_2 // 2)
 
+  def model_func_3(wrapped_import, inputs: torch.Tensor):
+    # test case (..., a, b, F,...) -> (..., b, a*F,...)
+    inputs = inputs.transpose(1, 2).contiguous()
+    return inputs.view(n_batch, n_time, n_feature_1 * n_feature_2)
+
   rnd = numpy.random.RandomState(42)
   x = rnd.normal(0., 1., (n_batch, n_time, n_feature_1, n_feature_2)).astype("float32")
   for model_func in [model_func_1, model_func_2]:
     verify_torch_and_convert_to_returnn(model_func, inputs=x, inputs_data_kwargs={
         "shape": (None, n_feature_1, n_feature_2), "batch_dim_axis": 0, "time_dim_axis": 1, "feature_dim_axis": 2})
+  x = rnd.normal(0., 1., (n_batch, n_feature_1, n_time, n_feature_2)).astype("float32")
+  verify_torch_and_convert_to_returnn(model_func_3, inputs=x, inputs_data_kwargs={
+      "shape": (n_feature_1, None, n_feature_2), "batch_dim_axis": 0, "time_dim_axis": 2, "feature_dim_axis": 3})
 
 
 def test_functional_conv():


### PR DESCRIPTION
When merging dims, the `MergeDimsLayer` target axis depends on whether the input feature dim axis is included in the merged dims or not. This was not covered in `MergeDims.generic_get_output_shape_from_returnn`. In case the feature dim axis was included in the merged dims and the merged dims were not adjacent, this leads to problems which this PR fixes.