### PR TITLE
fix loading params to returnn

### DIFF
--- a/pytorch_to_returnn/naming/naming.py
+++ b/pytorch_to_returnn/naming/naming.py
@@ -136,9 +136,8 @@ class Naming:
         x.returnn_data.name = f"param:{param_name}"
       parent_mod = x.get_canonical_parent_module()
       prefix = (parent_mod.get_canonical_name() + "_") if parent_mod else ""
-      mod = Variable(param=x.tensor())
+      mod = Variable(param=x.tensor(), parent_mod=(parent_mod.module, param_name))
       self.modules[mod].canonical_name = prefix + param_name
-      mod.parent_mod = (parent_mod.module, param_name)
       res = mod()
       res_tensor = self.tensors[res]
       assert isinstance(res_tensor, _tensor.TensorEntry)

--- a/pytorch_to_returnn/naming/naming.py
+++ b/pytorch_to_returnn/naming/naming.py
@@ -138,6 +138,7 @@ class Naming:
       prefix = (parent_mod.get_canonical_name() + "_") if parent_mod else ""
       mod = Variable(param=x.tensor())
       self.modules[mod].canonical_name = prefix + param_name
+      mod.parent_mod = (parent_mod.module, param_name)
       res = mod()
       res_tensor = self.tensors[res]
       assert isinstance(res_tensor, _tensor.TensorEntry)

--- a/pytorch_to_returnn/torch/nn/modules/variable.py
+++ b/pytorch_to_returnn/torch/nn/modules/variable.py
@@ -26,11 +26,12 @@ class Variable(Module):
     naming = Naming.get_instance()
     values = None
     if naming.import_params_from_torch_namespace and self.parent_mod:
-      parent_mod, param_name = self.parent_mod
-      mod_abs_name = naming.get_module_abs_id_name(parent_mod)
-      torch_mod = naming.import_params_from_torch_namespace.get_module_by_abs_id_name(mod_abs_name)
-      torch_param = getattr(torch_mod, param_name)
-      values = torch_param.detach().numpy()
+      if not ".tmp_root" in layer.network.name:  # temp layer
+        parent_mod, param_name = self.parent_mod
+        mod_abs_name = naming.get_module_abs_id_name(parent_mod)
+        torch_mod = naming.import_params_from_torch_namespace.get_module_by_abs_id_name(mod_abs_name)
+        torch_param = getattr(torch_mod, param_name)
+        values = torch_param.detach().numpy()
     if values is None:
       values = self.param.detach().numpy()
     assert isinstance(layer, VariableLayer)

--- a/pytorch_to_returnn/torch/nn/modules/variable.py
+++ b/pytorch_to_returnn/torch/nn/modules/variable.py
@@ -26,7 +26,7 @@ class Variable(Module):
     naming = Naming.get_instance()
     values = None
     if naming.import_params_from_torch_namespace and self.parent_mod:
-      if ".tmp_root" not in layer.network.name:  # temp layer
+      if not layer.get_absolute_name().startswith("."):  # temp layer
         parent_mod, param_name = self.parent_mod
         mod_abs_name = naming.get_module_abs_id_name(parent_mod)
         torch_mod = naming.import_params_from_torch_namespace.get_module_by_abs_id_name(mod_abs_name)

--- a/pytorch_to_returnn/torch/nn/modules/variable.py
+++ b/pytorch_to_returnn/torch/nn/modules/variable.py
@@ -26,7 +26,7 @@ class Variable(Module):
     naming = Naming.get_instance()
     values = None
     if naming.import_params_from_torch_namespace and self.parent_mod:
-      if not ".tmp_root" in layer.network.name:  # temp layer
+      if ".tmp_root" not in layer.network.name:  # temp layer
         parent_mod, param_name = self.parent_mod
         mod_abs_name = naming.get_module_abs_id_name(parent_mod)
         torch_mod = naming.import_params_from_torch_namespace.get_module_by_abs_id_name(mod_abs_name)

--- a/pytorch_to_returnn/torch/nn/modules/variable.py
+++ b/pytorch_to_returnn/torch/nn/modules/variable.py
@@ -13,24 +13,26 @@ from ....naming import Naming
 class Variable(Module):
   is_original_torch_module = False
 
-  def __init__(self, param: Parameter):
+  def __init__(self, param: Parameter, parent_mod: Optional[Tuple[Module, str]] = None):
     super(Variable, self).__init__()
     assert isinstance(param, Parameter)
     self.param = param
-    self.parent_mod = None
+    self.parent_mod = parent_mod
 
   def create_returnn_layer_dict(self, *inputs):  # ignore inputs
     return {"class": "variable", "add_batch_axis": False, "shape": self.param.shape}
 
   def make_output_tensor_from_returnn(self, inputs_flat: List[Tensor], layer: LayerBase) -> Tensor:
     naming = Naming.get_instance()
-    values = self.param.detach().numpy()
+    values = None
     if naming.import_params_from_torch_namespace and self.parent_mod:
-      if self.parent_mod[0].is_original_torch_module:
-        mod_abs_name = naming.get_module_abs_id_name(self.parent_mod[0])
-        torch_mod = naming.import_params_from_torch_namespace.get_module_by_abs_id_name(mod_abs_name)
-        values = torch_mod.weight.detach().numpy()
-
+      parent_mod, param_name = self.parent_mod
+      mod_abs_name = naming.get_module_abs_id_name(parent_mod)
+      torch_mod = naming.import_params_from_torch_namespace.get_module_by_abs_id_name(mod_abs_name)
+      torch_param = getattr(torch_mod, param_name)
+      values = torch_param.detach().numpy()
+    if values is None:
+      values = self.param.detach().numpy()
     assert isinstance(layer, VariableLayer)
     assert len(layer.params) == 1
     tf_param = list(layer.params.values())[0]


### PR DESCRIPTION
Loading the params to returnn works correctly when having a module `mod = torch.nn.Linear(n_in, n_out)` and calling it directly, i.e., `y = mod(x)`. However, if the params are used directly like `mod.weight`, they are not loaded in returnn currently.