### PR TITLE
assert correct torch shape of tensor entries

### DIFF
--- a/pytorch_to_returnn/torch/nn/modules/module.py
+++ b/pytorch_to_returnn/torch/nn/modules/module.py
@@ -636,6 +636,9 @@ class Module:
       returnn_output_np = returnn_output_np_.transpose(*[
         returnn_output_tensor_entry.returnn_axis_from_torch_axis[i] for i in range(returnn_output_np_.ndim)])
       torch_out_np = torch_mod_call.orig_outputs_flat[out_idx].detach().cpu().numpy()
+      assert torch_out_np.shape == tuple(int(i) for i in returnn_output_tensor_entry.tensor().shape), (
+        f"torch shape of TensorEntry does not match real torch shape: "
+        f"{torch_out_np.shape} vs. {returnn_output_tensor_entry}")
       error_msg_info = [f"RETURNN layer: {call.returnn_layer}", f"Torch module: {torch_mod}"]
       if returnn_output_np.shape != torch_out_np.shape:
         error_msg_info += [


### PR DESCRIPTION
Currently, it is not asserted that the `torch_shape` from `Module._get_output_shape_from_returnn` matches the actual torch shape. This is added here. This certainly will let existing tests using `_ConvNd` and `_ConvTransposedNd` fail. I'll add a fix in a separate PR.