### PR TITLE
fix torch shape for multiple modules

### DIFF
--- a/pytorch_to_returnn/torch/nn/modules/module.py
+++ b/pytorch_to_returnn/torch/nn/modules/module.py
@@ -783,12 +783,12 @@ class Module:
       assert isinstance(x, TensorEntry)
       assert x.returnn_data and x.returnn_axis_from_torch_axis is not None
       if x.returnn_data.have_batch_axis():
-        batch_size = input.shape[x.returnn_axis_from_torch_axis[x.returnn_data.batch_dim_axis]]
+        batch_size = input.shape[x.torch_axis_from_returnn_axis[x.returnn_data.batch_dim_axis]]
       for i in x.returnn_data.get_dynamic_axes():
         dim_tag_ext = _get_spatial_dim_tag_and_single_index(x.returnn_data, i)
         assert i in x.returnn_data.get_spatial_batch_axes()
         spatial_idx = x.returnn_data.get_spatial_batch_axes().index(i)
-        torch_dim = input.shape[x.returnn_axis_from_torch_axis[i]]
+        torch_dim = input.shape[x.torch_axis_from_returnn_axis[i]]
         if dim_tag_ext not in dyn_size_dim_tag_ext_to_spatial_idx_and_torch_dim:
           dyn_size_dim_tag_ext_to_spatial_idx_and_torch_dim[dim_tag_ext] = (spatial_idx, torch_dim)
 

--- a/pytorch_to_returnn/torch/nn/modules/padding.py
+++ b/pytorch_to_returnn/torch/nn/modules/padding.py
@@ -1,8 +1,8 @@
 
 from ...tensor import Tensor
 from .module import Module
-from typing import Union, Tuple, Optional, List, Dict
 from returnn.tf.layers.basic import LayerBase
+from typing import Union, Tuple, Optional, List, Dict
 from .utils import _pair, _quadruple, _ntuple
 from ..common_types import _size_2_t, _size_4_t, _size_6_t
 from ....naming import Naming
@@ -65,8 +65,7 @@ class GenericPadNd(Module):
   def _get_output_shape_from_returnn(self, inputs_flat: List[Tensor], layer: LayerBase
                                      ) -> Tuple[Tuple[int, ...], Dict[int, int]]:
     """
-    The basic returnn_axis_from_torch_axis should be correct, however, the torch shape is not adapted in the base method
-    and we fix it here.
+    The size of the dynamic axes might be changed, so we have to take care of this here for the torch shape.
     """
     torch_shape, returnn_axis_from_torch_axis = super(GenericPadNd, self)._get_output_shape_from_returnn(
       inputs_flat=inputs_flat, layer=layer)

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1008,6 +1008,20 @@ def test_depth_wise_conv1d():
   verify_torch_and_convert_to_returnn(model_func, inputs=x)
 
 
+def test_pad():
+  def model_func(wrapped_import, inputs: torch.Tensor):
+    if typing.TYPE_CHECKING or not wrapped_import:
+      import torch
+    else:
+      torch = wrapped_import("torch")
+
+    mod = torch.nn.ConstantPad1d((4, 1), 0)
+    return mod(inputs)
+
+  x = numpy.zeros((3, 5, 7)).astype("float32")
+  verify_torch_and_convert_to_returnn(model_func, inputs=x)
+
+
 if __name__ == "__main__":
   if len(sys.argv) <= 1:
     for k, v in sorted(globals().items()):


### PR DESCRIPTION
In #41 we introduced asserting the correct torch shape of tensor entries. There are multiple modules which have issues here. This PR fixes this by adding `_get_output_shape_from_returnn` for a number of modules.