### PR TITLE
allow setting shape for returnn dummy input

### DIFF
--- a/pytorch_to_returnn/converter/converter.py
+++ b/pytorch_to_returnn/converter/converter.py
@@ -7,7 +7,7 @@ import numpy
 import types
 import tempfile
 from pytorch_to_returnn.pprint import pprint
-from typing import Callable, Optional, Dict, Any
+from typing import Callable, Optional, Dict, Any, Tuple
 from returnn.tf.util.data import Data
 from pytorch_to_returnn import torch as torch_returnn
 from pytorch_to_returnn.import_wrapper import wrapped_import_torch_traced, wrapped_import_torch_returnn
@@ -64,6 +64,7 @@ class Converter:
                model_func: ModelFuncType, *,
                inputs: numpy.ndarray,
                inputs_data_kwargs: Optional[Dict[str, Any]] = None,
+               returnn_dummy_input_shape: Optional[Tuple[int]] = None,
                use_non_wrapped_reference: bool = True,
                verify_with_torch: bool = True,
                verify_individual_model_io: bool = True,
@@ -92,6 +93,7 @@ class Converter:
         inputs.shape[i] if i == inputs_data_kwargs["feature_dim_axis"] else None
         for i in range(1, len(inputs.shape))]
     self._returnn_in_data_dict = inputs_data_kwargs
+    self._returnn_dummy_input_shape = returnn_dummy_input_shape
     self.use_non_wrapped_reference = use_non_wrapped_reference
     self.verify_with_torch = verify_with_torch
     self.verify_individual_model_io = verify_individual_model_io
@@ -274,6 +276,8 @@ class Converter:
         # We assume this would be flattened away in the namespace.
         # All named modules should thus have the same names.
         class DummyModule(torch_returnn.nn.Module):
+          returnn_dummy_input_shape = self._returnn_dummy_input_shape
+
           def get_returnn_name(self) -> str:
             return ""  # also avoid that this name becomes a prefix anywhere
 

--- a/pytorch_to_returnn/torch/nn/init.py
+++ b/pytorch_to_returnn/torch/nn/init.py
@@ -21,7 +21,8 @@ def _calculate_fan_in_and_fan_out(tensor: Tensor):
   num_output_fmaps = tensor.size(0)
   receptive_field_size = 1
   if tensor.dim() > 2:
-    receptive_field_size = tensor[0][0].numel()
+    for s in tensor.shape[2:]:
+      receptive_field_size *= s
   fan_in = num_input_fmaps * receptive_field_size
   fan_out = num_output_fmaps * receptive_field_size
 

--- a/pytorch_to_returnn/torch/nn/modules/module.py
+++ b/pytorch_to_returnn/torch/nn/modules/module.py
@@ -922,12 +922,15 @@ class Module:
 
   @classmethod
   def _make_returnn_dummy_input(cls, data: Data) -> numpy.ndarray:
-    some_primes = (3, 5, 7, 11, 13)  # use primes for dynamic dims, just nicer to identify in logs
-    dynamic_axes = [i for i, dim in enumerate(data.batch_shape) if dim is None]
-    assert len(dynamic_axes) <= len(some_primes)  # just not implemented otherwise
-    shape = list(data.batch_shape)
-    for i, j in enumerate(dynamic_axes):
-      shape[j] = some_primes[i]
+    if cls.returnn_dummy_input_shape is not None:
+      shape = cls.returnn_dummy_input_shape
+    else:
+      some_primes = (3, 5, 7, 11, 13)  # use primes for dynamic dims, just nicer to identify in logs
+      dynamic_axes = [i for i, dim in enumerate(data.batch_shape) if dim is None]
+      assert len(dynamic_axes) <= len(some_primes)  # just not implemented otherwise
+      shape = list(data.batch_shape)
+      for i, j in enumerate(dynamic_axes):
+        shape[j] = some_primes[i]
     return numpy.zeros(shape, dtype=data.dtype)
 
   def _returnn_dummy_call(self, *returnn_inputs: Dict[str, Any]) -> Naming:

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1022,6 +1022,26 @@ def test_pad():
   verify_torch_and_convert_to_returnn(model_func, inputs=x)
 
 
+def test_dummy_input_shape():
+  n_in, n_out = 11, 11
+  n_batch, n_time = 3, 999
+
+  def model_func(wrapped_import, inputs: torch.Tensor):
+    if typing.TYPE_CHECKING or not wrapped_import:
+      import torch
+    else:
+      torch = wrapped_import("torch")
+    model = torch.nn.Conv1d(in_channels=n_in, out_channels=n_out, kernel_size=5, stride=5)
+    x = inputs
+    for i in range(3):
+      x = model(x)
+    return x
+
+  rnd = numpy.random.RandomState(42)
+  x = rnd.normal(0., 1., (n_batch, n_in, n_time)).astype("float32")
+  verify_torch_and_convert_to_returnn(model_func, inputs=x, returnn_dummy_input_shape=x.shape)
+
+
 if __name__ == "__main__":
   if len(sys.argv) <= 1:
     for k, v in sorted(globals().items()):


### PR DESCRIPTION
The returnn dummy input uses arbitrary sizes for the dynamic axes. I had a case where the size of the time dim was reduced by convolutions such that the chosen arbitrary size was too small (see added test case). For such situations, I added the option `returnn_dummy_input_shape` for the `Converter` so that the dummy input shape can be manually set.