### PR TITLE
Fix F.pad in case the padding happens in multiple dimensions

### DIFF
--- a/pytorch_to_returnn/torch/nn/modules/padding.py
+++ b/pytorch_to_returnn/torch/nn/modules/padding.py
@@ -1,7 +1,8 @@
 
 from ...tensor import Tensor
 from .module import Module
-from typing import Union, Tuple, Optional
+from typing import Union, Tuple, Optional, List, Dict
+from returnn.tf.layers.basic import LayerBase
 from .utils import _pair, _quadruple, _ntuple
 from ..common_types import _size_2_t, _size_4_t, _size_6_t
 from ....naming import Naming
@@ -60,6 +61,20 @@ class GenericPadNd(Module):
     if self.mode == "constant":
       d["value"] = self.value
     return d
+
+  def _get_output_shape_from_returnn(self, inputs_flat: List[Tensor], layer: LayerBase
+                                     ) -> Tuple[Tuple[int, ...], Dict[int, int]]:
+    """
+    The basic returnn_axis_from_torch_axis should be correct, however, the torch shape is not adapted in the base method
+    and we fix it here.
+    """
+    torch_shape, returnn_axis_from_torch_axis = super(GenericPadNd, self)._get_output_shape_from_returnn(
+      inputs_flat=inputs_flat, layer=layer)
+    assert len(inputs_flat) == 1
+    torch_shape = list(inputs_flat[0].shape)
+    for idx in range(len(self.padding) // 2):
+      torch_shape[-1 - idx] += self.padding[2 * idx] + self.padding[2 * idx + 1]
+    return tuple(torch_shape), returnn_axis_from_torch_axis
 
 
 class _ConstantPadNd(GenericPadNd):

--- a/pytorch_to_returnn/torch/nn/modules/padding.py
+++ b/pytorch_to_returnn/torch/nn/modules/padding.py
@@ -4,6 +4,7 @@ from .module import Module
 from typing import Union, Tuple, Optional
 from .utils import _pair, _quadruple, _ntuple
 from ..common_types import _size_2_t, _size_4_t, _size_6_t
+from ....naming import Naming
 
 
 class GenericPadNd(Module):
@@ -25,11 +26,27 @@ class GenericPadNd(Module):
     assert self.mode != "replicate"  # not implemented
     assert len(self.padding) % 2 == 0, 'Padding needs to be a multiple of 2'
 
+    naming = Naming.get_instance()
+    input_naming = naming.tensors[input]
+
+    # These are the axes in which RETURNN will pad.
+    spatial_returnn = input_naming.returnn_data.get_axes_from_description("spatial")
+    # This stores the RETURNN axes which map to the torch axes we want to pad
+    spatial_torch_mapped = [input_naming.returnn_axis_from_torch_axis[i]
+                            for i in range(len(input.shape) - len(self.padding) // 2, len(input.shape))]
+
     # PyTorch specifies the padding in one big tuple
-    # e.g. (1,1,1,1) to pad by 1 in each direction of the last 2 dimensions
+    # e.g. (1, 1, 2, 2) to pad by 2 in the last and by 1 in the second to last axis in each direction.
     # RETURNN however takes padding split by axis
-    # e.g. [(1,1), (1,1)]
-    returnn_padding = [(self.padding[2 * i], self.padding[2 * i + 1]) for i in range(len(self.padding) // 2)]
+    # e.g. [(1,1), (2,2)].
+    # This is not yet in the correct order of the spatial axes.
+    split_padding = [(self.padding[2 * i], self.padding[2 * i + 1])
+                     for i in range((len(self.padding) // 2) - 1, -1, -1)]
+
+    returnn_padding = [(0, 0) for _ in range(len(spatial_returnn))]
+    for i, padding in enumerate(split_padding):
+      index = spatial_returnn.index(spatial_torch_mapped[i])
+      returnn_padding[index] = padding
 
     # PyTorch assumes the input to be in batch-feature-major.
     # E.g. for 1D, it assumes input (N, C, W_in),

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -381,6 +381,19 @@ def test_reshape_a_b_F_to_b_aF():
       "shape": (n_feature_1, None, n_feature_2), "batch_dim_axis": 0, "time_dim_axis": 2, "feature_dim_axis": 3})
 
 
+def test_pad():
+  def model_func(wrapped_import, inputs: torch.Tensor):
+    if typing.TYPE_CHECKING or not wrapped_import:
+      import torch.nn.functional as F
+    else:
+      F = wrapped_import("torch.nn.functional")
+
+    return F.pad(inputs, (1,1,2,2))
+
+  x = numpy.zeros((1,1,4,4)).astype("float32")
+  verify_torch_and_convert_to_returnn(model_func, inputs=x)
+
+
 def test_functional_conv():
   n_in, n_out = 11, 13
   n_batch, n_time = 3, 7

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -388,9 +388,9 @@ def test_pad():
     else:
       F = wrapped_import("torch.nn.functional")
 
-    return F.pad(inputs, (1,1,2,2))
+    return F.pad(inputs, (1, 1, 2, 2))
 
-  x = numpy.zeros((1,1,4,4)).astype("float32")
+  x = numpy.zeros((1, 1, 4, 4)).astype("float32")
   verify_torch_and_convert_to_returnn(model_func, inputs=x)
 
 

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -388,7 +388,9 @@ def test_pad():
     else:
       F = wrapped_import("torch.nn.functional")
 
-    return F.pad(inputs, (1, 1, 2, 2))
+    inputs = F.pad(inputs, (1, 1, 2, 2))
+    inputs = F.pad(inputs, (1, 1))
+    return inputs
 
   x = numpy.zeros((1, 1, 4, 4)).astype("float32")
   verify_torch_and_convert_to_returnn(model_func, inputs=x)


### PR DESCRIPTION
The current implementation of F.pad fails when the padding tuple has more than 2 entries, because RETURNN expects the padding to be split up by axes.