### PR TITLE
add tensor.ndimension()

### DIFF
--- a/pytorch_to_returnn/torch/tensor.py
+++ b/pytorch_to_returnn/torch/tensor.py
@@ -50,6 +50,9 @@ class Tensor:
   def dim(self):
     return len(self._shape)
 
+  def ndimension(self):
+    return self.dim()
+
   @property
   def ndim(self):
     return self.dim()


### PR DESCRIPTION
`tensor.ndimension()` is an alias for `tensor.dim()`, see https://pytorch.org/docs/stable/generated/torch.Tensor.ndimension.html