### PR TITLE
added test for using unsqueeze together with transposed convolution

### DIFF
--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -219,15 +219,15 @@ def test_conv_transposed_2d():
 
 
 def test_conv_transposed_2d_with_unsqueeze():
-  n_in, n_out = 512, 512
-  n_batch, n_features, n_time = 4, 512, 355 
+  n_in, n_out = 16, 16
+  n_batch, n_features, n_time = 4, 16, 20
 
   def model_func(wrapped_import, inputs: torch.Tensor):
     if typing.TYPE_CHECKING or not wrapped_import:
       import torch
     else:
       torch = wrapped_import("torch")
-    inputs = inputs.unsqueeze(-1)
+    inputs = inputs.unsqueeze(-1)  # (B, F, T, 1)
     model = torch.nn.ConvTranspose2d(
       in_channels=n_in,
       out_channels=n_out,

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -218,6 +218,27 @@ def test_conv_transposed_2d():
   verify_torch_and_convert_to_returnn(model_func, inputs=x)
 
 
+def test_conv_transposed_2d_with_unsqueeze():
+  n_in, n_out = 512, 512
+  n_batch, n_features, n_time = 4, 512, 355 
+
+  def model_func(wrapped_import, inputs: torch.Tensor):
+    if typing.TYPE_CHECKING or not wrapped_import:
+      import torch
+    else:
+      torch = wrapped_import("torch")
+    inputs = inputs.unsqueeze(-1)
+    model = torch.nn.ConvTranspose2d(
+      in_channels=n_in,
+      out_channels=n_out,
+      kernel_size=(1, 12))
+    return model(inputs)
+
+  rnd = numpy.random.RandomState(42)
+  x = rnd.normal(0., 1., (n_batch, n_features, n_time)).astype("float32")
+  verify_torch_and_convert_to_returnn(model_func, inputs=x)
+
+
 def test_functional_linear():
   n_in, n_out = 11, 13
   n_batch, n_time = 3, 7


### PR DESCRIPTION
I am running into trouble when using unsqueeze together with transposed convolution after the changes for the explicit data dimension tags. I  dont really know what the problem is though. I added a test case which should reproduce the problem.

The error is given by:
```
File "/u/dierkes/pytorch-to-returnn-projects/pytorch-to-returnn-fork/pytorch-to-returnn/tests/returnn/returnn/tf/util/data.py", line 178, in DimensionTag.set_tag_on_size_
tensor
    line: assert x._is_size_of_dim_tag in (None, self)
    locals:
      x = <local> <tf.Tensor 'extern_data/placeholders/data/data_dim1_size:0' shape=(?,) dtype=int32>
      x._is_size_of_dim_tag = <local> DimensionTag{'time:var:extern_data:data'[B]}
      self = <local> DimensionTag{'ConvTranspose2d_spatial0_transposed_conv'[?]}
AssertionError
```
