### PR TITLE
Added test for using tensor.view for removing an axis

### DIFF
--- a/pytorch_to_returnn/torch/nn/modules/module.py
+++ b/pytorch_to_returnn/torch/nn/modules/module.py
@@ -848,8 +848,8 @@ class Module:
     rem_torch_axes = set(range(layer.output.batch_ndim)).difference(set(out_returnn_axis_to_torch_axis.values()))
     rem_returnn_axes = set(range(layer.output.batch_ndim)).difference(set(out_returnn_axis_to_torch_axis.keys()))
     assert len(rem_torch_axes) == len(rem_returnn_axes)
-    rem_torch_axes_ = sorted(rem_torch_axes)
-    rem_returnn_axes_ = sorted(rem_returnn_axes)
+    rem_torch_spatial_axes = sorted([ax for ax in rem_torch_axes if ax in layer.output.get_dynamic_axes()])
+    rem_returnn_spatial_axes = sorted([ax for ax in rem_returnn_axes if ax in layer.output.get_dynamic_axes()])
 
     out_shape = list(layer.output.batch_shape)
     if layer.output.have_batch_axis():
@@ -862,11 +862,11 @@ class Module:
         if dim_tag_ext in dyn_size_dim_tag_ext_to_spatial_idx_and_torch_dim:
           in_spatial_idx, out_shape[i] = dyn_size_dim_tag_ext_to_spatial_idx_and_torch_dim[dim_tag_ext]
           if i in rem_returnn_axes:
-            out_spatial_idx = rem_returnn_axes_.index(i)
+            out_spatial_idx = rem_returnn_spatial_axes.index(i)
             if in_spatial_idx != out_spatial_idx:
-              out_returnn_axis_to_torch_axis[i] = rem_torch_axes_[in_spatial_idx]
+              out_returnn_axis_to_torch_axis[i] = rem_torch_spatial_axes[in_spatial_idx]
               rem_returnn_axes.remove(i)
-              rem_torch_axes.remove(rem_torch_axes_[in_spatial_idx])
+              rem_torch_axes.remove(rem_torch_spatial_axes[in_spatial_idx])
         else:
           # Assume same order.
           assert len(layer.output.get_dynamic_axes()) == len(dyn_size_dim_tag_ext_to_spatial_idx_and_torch_dim)

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -219,15 +219,15 @@ def test_conv_transposed_2d():
 
 
 def test_conv_transposed_2d_with_unsqueeze():
-  n_in, n_out = 512, 512
-  n_batch, n_features, n_time = 4, 512, 355 
+  n_in, n_out = 16, 16
+  n_batch, n_features, n_time = 4, 16, 20
 
   def model_func(wrapped_import, inputs: torch.Tensor):
     if typing.TYPE_CHECKING or not wrapped_import:
       import torch
     else:
       torch = wrapped_import("torch")
-    inputs = inputs.unsqueeze(-1)
+    inputs = inputs.unsqueeze(-1)  # (B, F, T, 1)
     model = torch.nn.ConvTranspose2d(
       in_channels=n_in,
       out_channels=n_out,

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -218,6 +218,27 @@ def test_conv_transposed_2d():
   verify_torch_and_convert_to_returnn(model_func, inputs=x)
 
 
+def test_conv_transposed_2d_with_unsqueeze():
+  n_in, n_out = 512, 512
+  n_batch, n_features, n_time = 4, 512, 355 
+
+  def model_func(wrapped_import, inputs: torch.Tensor):
+    if typing.TYPE_CHECKING or not wrapped_import:
+      import torch
+    else:
+      torch = wrapped_import("torch")
+    inputs = inputs.unsqueeze(-1)
+    model = torch.nn.ConvTranspose2d(
+      in_channels=n_in,
+      out_channels=n_out,
+      kernel_size=(1, 12))
+    return model(inputs)
+
+  rnd = numpy.random.RandomState(42)
+  x = rnd.normal(0., 1., (n_batch, n_features, n_time)).astype("float32")
+  verify_torch_and_convert_to_returnn(model_func, inputs=x)
+
+
 def test_functional_linear():
   n_in, n_out = 11, 13
   n_batch, n_time = 3, 7

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -402,6 +402,24 @@ def test_reshape_a_b_F_to_b_aF():
       "shape": (n_feature_1, None, n_feature_2), "batch_dim_axis": 0, "time_dim_axis": 2, "feature_dim_axis": 3})
 
 
+def test_view():
+  #n_in, n_out = 11, 13
+  n_batch, n_time, n_feature = 2, 20, 1
+
+  def model_func(wrapped_import, inputs: torch.Tensor):
+    if typing.TYPE_CHECKING or not wrapped_import:
+      import torch
+    else:
+      torch = wrapped_import("torch")
+    out = inputs.view(inputs.shape[:2]) # (B, T, F)
+    return out
+
+  rnd = numpy.random.RandomState(42)
+  x = rnd.normal(0., 1., (n_batch, n_time, n_feature)).astype("float32")
+  verify_torch_and_convert_to_returnn(model_func, inputs=x, returnn_dummy_input_shape=x.shape, inputs_data_kwargs={
+      "shape": (None, n_feature), "batch_dim_axis": 0, "time_dim_axis": 1, "feature_dim_axis": 2})
+
+
 def test_pad():
   def model_func(wrapped_import, inputs: torch.Tensor):
     if typing.TYPE_CHECKING or not wrapped_import:

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -402,11 +402,12 @@ def test_reshape_a_b_F_to_b_aF():
       "shape": (n_feature_1, None, n_feature_2), "batch_dim_axis": 0, "time_dim_axis": 2, "feature_dim_axis": 3})
 
 
-def test_view():
+def test_reshape_a_b_1_to_a_b():
   #n_in, n_out = 11, 13
   n_batch, n_time, n_feature = 2, 20, 1
 
   def model_func(wrapped_import, inputs: torch.Tensor):
+    # test case (a, b, 1) -> (a, b)
     if typing.TYPE_CHECKING or not wrapped_import:
       import torch
     else:


### PR DESCRIPTION
I ran into a problem using the method tensor.view in order to remove an axis with dimension 1. I think the output shape of the tensor is permuted in an undesired manner in reshape. I created a test to reproduce the problem. 