### PR TITLE
Broadcasting after transpose

### DIFF
--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -798,6 +798,22 @@ def test_broadcast_with_different_axes_types():
   verify_torch_and_convert_to_returnn(model_func, inputs=x)
 
 
+def test_broadcast_after_transpose():
+  n_batch, n_time, n_feature = 3, 7, 5
+
+  def model_func(wrapped_import, inputs: torch.Tensor):
+    if typing.TYPE_CHECKING or not wrapped_import:
+      import torch
+    else:
+      torch = wrapped_import("torch")
+    weight = torch.ones(n_feature)
+    return inputs.transpose(1, 2) * weight
+
+  rnd = numpy.random.RandomState(42)
+  x = rnd.normal(0., 1., (n_batch, n_feature, n_time)).astype("float32")
+  verify_torch_and_convert_to_returnn(model_func, inputs=x)
+
+
 def test_broadcast_add_bias():
   n_batch, n_feature = 3, 5
 


### PR DESCRIPTION
In the case of a multiplication of a transposed tensor with some other tensor, we currently run into issues when matching axes, see also https://github.com/rwth-i6/returnn/issues/719

I added a testcase to demonstrate the problem. If the logic in `_unify_tensor_axes_returnn_meta()` would not add a broadcasting dim, this would work fine.