### PR TITLE
add dummies to avoid import errors

### DIFF
--- a/pytorch_to_returnn/torch/__init__.py
+++ b/pytorch_to_returnn/torch/__init__.py
@@ -8,3 +8,5 @@ from . import nn
 from . import cuda
 from . import onnx
 from . import jit
+
+__version__ = "1.8.1"

--- a/pytorch_to_returnn/torch/distributions.py
+++ b/pytorch_to_returnn/torch/distributions.py
@@ -1,0 +1,10 @@
+class Normal:
+  pass
+
+
+class MultivariateNormal:
+  pass
+
+
+def kl_divergence():
+  pass

--- a/pytorch_to_returnn/torch/nn/__init__.py
+++ b/pytorch_to_returnn/torch/nn/__init__.py
@@ -2,4 +2,5 @@
 from .modules import *
 from .parameter import Parameter
 from . import init
+from . import parallel
 from . import utils

--- a/pytorch_to_returnn/torch/nn/functional.py
+++ b/pytorch_to_returnn/torch/nn/functional.py
@@ -695,3 +695,23 @@ def multi_head_attention_forward(
     return attn_output, attn_output_weights.sum(dim=1) / num_heads
   else:
     return attn_output, None
+
+
+def mse_loss():
+  raise NotImplementedError
+
+
+def ceil():
+  raise NotImplementedError
+
+
+def clamp():
+  raise NotImplementedError
+
+
+def exp():
+  raise NotImplementedError
+
+
+def log10():
+  raise NotImplementedError

--- a/pytorch_to_returnn/torch/nn/modules/activation.py
+++ b/pytorch_to_returnn/torch/nn/modules/activation.py
@@ -20,6 +20,14 @@ class GELU(_ActivationReturnn):
   func_name = "gelu3"
 
 
+class PReLU(_ActivationReturnn):
+  pass
+
+
+class ELU(_ActivationReturnn):
+  pass
+
+
 class Abs(_ActivationReturnn):
   func_name = "abs"
 

--- a/pytorch_to_returnn/torch/nn/parallel.py
+++ b/pytorch_to_returnn/torch/nn/parallel.py
@@ -1,0 +1,14 @@
+class DistributedDataParallel:
+  pass
+
+
+def gather():
+  pass
+
+
+def parallel_apply():
+  pass
+
+
+def replicate():
+  pass

--- a/pytorch_to_returnn/torch/optim/__init__.py
+++ b/pytorch_to_returnn/torch/optim/__init__.py
@@ -1,0 +1,14 @@
+
+from . import lr_scheduler
+
+
+class Adam:
+  pass
+
+
+class Adadelta:
+  pass
+
+
+class SGD:
+  pass

--- a/pytorch_to_returnn/torch/optim/lr_scheduler.py
+++ b/pytorch_to_returnn/torch/optim/lr_scheduler.py
@@ -1,0 +1,2 @@
+class _LRScheduler:
+  pass

--- a/pytorch_to_returnn/torch/tensor.py
+++ b/pytorch_to_returnn/torch/tensor.py
@@ -94,6 +94,10 @@ class Tensor:
   def clone(self):
     return self  # ignore
 
+  def cpu(self):
+    return self  # ignore
+
+  @property
   def device(self):
     return None  # ignore
 
@@ -291,3 +295,9 @@ class LongTensor(Tensor):
 class FloatTensor(Tensor):
   def __init__(self, *args):
     super(FloatTensor, self).__init__(dtype="float32", *args)
+
+
+class IntTensor(Tensor):
+  def __init__(self, *args):
+    super(FloatTensor, self).__init__(dtype="int32", *args)
+


### PR DESCRIPTION
Add dummies to avoid import errors. For `torch.__version__`, I used 1.8.1 because that is currently used in the tests here.