### PR TITLE
Naming.push_module_call: fix for unregist. tensors

### DIFF
--- a/pytorch_to_returnn/naming/naming.py
+++ b/pytorch_to_returnn/naming/naming.py
@@ -193,8 +193,9 @@ class Naming:
       entry.orig_inputs_kwargs = inputs_kwargs
       entry.orig_inputs_flat = inputs_flat
     entry.inputs_flat = [self._make_tensor(x) for x in inputs_flat]
-    entry.inputs_args, entry.inputs_kwargs = nest.pack_sequence_as(
-      structure=(inputs_args, inputs_kwargs), flat_sequence=entry.inputs_flat)
+    if self.wrap_to_returnn_enabled:
+      entry.inputs_args, entry.inputs_kwargs = nest.pack_sequence_as(
+        structure=(inputs_args, inputs_kwargs), flat_sequence=entry.inputs_flat)
     entry.level = len(self.module_call_stack)
     if self.module_call_stack:
       recent_entry = self.module_call_stack[-1]


### PR DESCRIPTION
If a `Module` is called in the code that should be converted, we go through `Naming.push_module_call` already in `_run_traced_orig_torch()`. There we obtain `entry.inputs_flat = [self._make_tensor(x) for x in inputs_flat]`. Since the tensors are not registered there, we get `None`s there. This can potentially lead to errors in the subsequend nesting. As `entry.inputs_args` and `entry.inputs_kwargs` are not used in `_run_traced_orig_torch()`, we can avoid the nesting in this case.