### PR TITLE
Add permute

### DIFF
--- a/pytorch_to_returnn/torch/nn/functional.py
+++ b/pytorch_to_returnn/torch/nn/functional.py
@@ -36,7 +36,7 @@ def ones(*size, out=None, dtype=None, layout=None, device=None, requires_grad=Fa
   return tensor(numpy.ones(size, dtype=dtype))
 
 
-def arange(*args, out: Optional[Tensor]=None, dtype: Optional[_dtype]=None, device=None, 
+def arange(*args, out: Optional[Tensor]=None, dtype: Optional[_dtype]=None, device=None,
            requires_grad: bool=False) -> Tensor:
   assert 1 <= len(args) <= 3
   if len(args) == 3:
@@ -266,6 +266,10 @@ def movedim(input: Tensor, source: Union[int, Tuple[int, ...]], destination: Uni
 
 def transpose(input: Tensor, dim0: int, dim1: int):
   return tensorflow_transpose(input, perm={dim0: dim1, dim1: dim0})
+
+
+def permute(input: Tensor, dims: Tuple[int]):
+  return tensorflow_transpose(input, perm=dims)
 
 
 def t(input: Tensor):

--- a/pytorch_to_returnn/torch/nn/modules/operator.py
+++ b/pytorch_to_returnn/torch/nn/modules/operator.py
@@ -260,9 +260,10 @@ class Transpose(Module):
     assert tensor_entry.returnn_data and tensor_entry.returnn_axis_from_torch_axis
     assert tensor_entry.returnn_data.batch_ndim == ndim
 
+    inv_perm = {j: i for i, j in perm.items()}
     out_torch_shape = [input.shape[perm[i]] for i in range(ndim)]
     out_returnn_axis_from_torch_axis = {
-      perm[i]: j for (i, j) in tensor_entry.returnn_axis_from_torch_axis.items()}
+      inv_perm[i]: j for (i, j) in tensor_entry.returnn_axis_from_torch_axis.items()}
     return tuple(out_torch_shape), out_returnn_axis_from_torch_axis
 
 

--- a/pytorch_to_returnn/torch/tensor.py
+++ b/pytorch_to_returnn/torch/tensor.py
@@ -127,6 +127,14 @@ class Tensor:
     from .nn.functional import transpose
     return transpose(self, dim0=dim0, dim1=dim1)
 
+  def permute(self, *dims):
+    if dims and isinstance(dims[0], (tuple, list)):
+      assert len(dims) == 1
+      dims = tuple(dims[0])
+    assert isinstance(dims, tuple)
+    from .nn.functional import permute
+    return permute(self, dims=dims)
+
   def t(self):
     from .nn.functional import t
     return t(self)

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1033,6 +1033,18 @@ def test_movedim_2():
   verify_torch_and_convert_to_returnn(model_func, inputs=x)
 
 
+def test_permute():
+  n_batch, n_time, n_feature = 3, 5, 7
+
+  def model_func(wrapped_import, inputs: torch.Tensor):
+    out = inputs.permute(2, 0, 1)
+    return out
+
+  rnd = numpy.random.RandomState(42)
+  x = rnd.normal(0., 1., (n_batch, n_feature, n_time)).astype("float32")
+  verify_torch_and_convert_to_returnn(model_func, inputs=x)
+
+
 def test_flatten_batch():
   n_in, n_out = 11, 13
   n_batch, n_time = 3, 7

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1017,6 +1017,22 @@ def test_movedim():
   verify_torch_and_convert_to_returnn(model_func, inputs=x)
 
 
+def test_movedim_2():
+  n_batch, n_time, n_feature = 3, 5, 7
+
+  def model_func(wrapped_import, inputs: torch.Tensor):
+    if typing.TYPE_CHECKING or not wrapped_import:
+      import torch
+    else:
+      torch = wrapped_import("torch")
+    out = torch.movedim(inputs, 0, 2)
+    return out
+
+  rnd = numpy.random.RandomState(42)
+  x = rnd.normal(0., 1., (n_batch, n_feature, n_time)).astype("float32")
+  verify_torch_and_convert_to_returnn(model_func, inputs=x)
+
+
 def test_flatten_batch():
   n_in, n_out = 11, 13
   n_batch, n_time = 3, 7


### PR DESCRIPTION
Add `torch.nn.functional.permute` and `Tensor.permute` which uses the previous one. In order to do this, I also fixed `out_returnn_axis_from_torch_axis` for `Transpose`. Apparently, we only had cases where two axes were transposed, not where a more complicated transpose was done like 0->1, 1->2, 2->0, so the error did not become obvious before.