### PR TITLE
rebase and extend torch.cat

### DIFF
--- a/pytorch_to_returnn/torch/nn/modules/operator.py
+++ b/pytorch_to_returnn/torch/nn/modules/operator.py
@@ -34,16 +34,15 @@ class Cat(Module):
 
   def create_returnn_layer_dict(self, *inputs: Tensor) -> Dict[str, Any]:
     naming = Naming.get_instance()
+    sources = []
     for input in inputs:
       dim = self.dim
-      assert -len(input.shape) <= dim < len(input.shape)
       if dim < 0:
         dim += len(input.shape)
       assert 0 <= dim < len(input.shape)
-      input_naming = naming.tensors[input]
-      returnn_axis = input_naming.returnn_axis_from_torch_axis[dim]
-      assert returnn_axis == input_naming.returnn_data.feature_dim_axis, "Concatenation in dimensions other than the feature dimension is currently not supported."
-    return {"class": "copy", "from": [self._get_input_layer_name(input) for input in inputs]}
+      returnn_axis = self._get_input_axis_to_returnn(input, axis=dim)
+      sources.append((self._get_input_layer_name(input), returnn_axis))
+    return {"class": "concat", "from": sources}
 
 
 class GetSublayer(Module):

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -113,14 +113,32 @@ def test_load_params_in_returnn_with_initializer():
 def test_cat():
 
   def model_func(wrapped_import, inputs: torch.Tensor):
-      if wrapped_import:
-        torch = wrapped_import("torch")
-      else:
-        import torch
-      return torch.cat((inputs, inputs), dim=-1)
+    if wrapped_import:
+      torch = wrapped_import("torch")
+    else:
+      import torch
+    return torch.cat((inputs, inputs), dim=-1)
 
   rnd = numpy.random.RandomState(42)
-  x = rnd.normal(0., 1., (3,3)).astype("float32")
+  x = rnd.normal(0., 1., (3, 3)).astype("float32")
+  verify_torch_and_convert_to_returnn(model_func, inputs=x)
+
+
+def test_cat_non_feature():
+  n_batch, n_time, n_feat = 3, 5, 7
+
+  def model_func(wrapped_import, inputs: torch.Tensor):
+    if wrapped_import:
+      torch = wrapped_import("torch")
+    else:
+      import torch
+
+    x = inputs.expand(1, n_batch, n_feat, n_time)
+    y = inputs.expand(3, n_batch, n_feat, n_time)
+    return torch.cat([x, y], dim=0)
+
+  rnd = numpy.random.RandomState(42)
+  x = rnd.normal(0., 1., (n_batch, n_feat, n_time)).astype("float32")
   verify_torch_and_convert_to_returnn(model_func, inputs=x)
 
 


### PR DESCRIPTION
Rebase `torch.cat` to use RETURNN's `ConcatLayer`, which makes it more flexible. In particular, also other dims than feature can now be concatenated.