### PR TITLE
fix Unflatten out_returnn_axis_from_torch_axis

### DIFF
--- a/pytorch_to_returnn/torch/nn/modules/shape.py
+++ b/pytorch_to_returnn/torch/nn/modules/shape.py
@@ -269,7 +269,7 @@ class Unflatten(Module):
       unflatten_idx = None
       if i < dim:
         old_torch_axis = i
-      elif i > dim + len(unflatten_size):
+      elif i >= dim + len(unflatten_size):
         old_torch_axis = i - len(unflatten_size) + 1
       else:  # i >= dim and ..., within the unflattened dims
         unflatten_idx = i - dim

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -993,6 +993,19 @@ def test_unsqueeze2():
   verify_torch_and_convert_to_returnn(model_func, inputs=x)
 
 
+def test_transpose_unsqueeze():
+  n_batch, n_time, n_feat = 3, 5, 7
+
+  def model_func(wrapped_import, inputs: torch.Tensor):
+    x = inputs.transpose(1, 2)
+    x = x.unsqueeze(0)
+    return x
+
+  rnd = numpy.random.RandomState(42)
+  x = rnd.normal(0., 1., (n_batch, n_feat, n_time)).astype("float32")
+  verify_torch_and_convert_to_returnn(model_func, inputs=x)
+
+
 def test_broadcast_with_different_axes_types():
   n_batch, n_time, n_feature = 3, 7, 5
 


### PR DESCRIPTION
The `elif` branch that I edited is supposed to be the case where `i` refers to a dim which outside (larger than) the unflattened dims. Equality should also be contained in this case.