### PR TITLE
allow indexing tensor with none

### DIFF
--- a/pytorch_to_returnn/torch/tensor.py
+++ b/pytorch_to_returnn/torch/tensor.py
@@ -252,6 +252,8 @@ class Tensor:
     elif isinstance(item, slice):
       from .nn import Slice
       return Slice(axis=0, start=item.start, stop=item.stop, step=item.step)(self)
+    elif item is None:
+      return self.unsqueeze(0)
     elif isinstance(item, tuple):
       assert len(item) == self.ndim
       from .nn import Gather, GatherTensor, Slice

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1197,6 +1197,18 @@ def test_slice_tensor():
     "shape": (None, n_in), "batch_dim_axis": 0, "time_dim_axis": 1, "feature_dim_axis": 2})
 
 
+def test_index_none():
+  n_batch, n_time, n_feat = 3, 5, 7
+
+  def model_func(wrapped_import, inputs: torch.Tensor):
+    x = inputs[None]
+    return x
+
+  rnd = numpy.random.RandomState(42)
+  x = rnd.normal(0., 1., (n_batch, n_feat, n_time)).astype("float32")
+  verify_torch_and_convert_to_returnn(model_func, inputs=x)
+
+
 def test_expand():
   n_batch, n_feat = 5, 1
 


### PR DESCRIPTION
`x[None]` is the same as `x.unsqueeze(0)`.