### PR TITLE
do not use FlattenBatchLayer in MergeDims

### DIFF
--- a/pytorch_to_returnn/torch/nn/modules/shape.py
+++ b/pytorch_to_returnn/torch/nn/modules/shape.py
@@ -25,7 +25,6 @@ _NamedShape = Tuple[Tuple[str, int]]
 class MergeDims(Module):
   """
   Maps to RETURNN MergeDimsLayer, if batch axis is not involved.
-  In case batch axis is involved, this uses RETURNN FlattenBatchLayer.
 
   Used by Flatten, and thus indirectly by various kinds of reshape.
   """
@@ -50,18 +49,6 @@ class MergeDims(Module):
       return d
 
     dims = [_pos_dim(d) for d in dims]
-    returnn_axes = [in_.returnn_axis_from_torch_axis[d] for d in dims]
-    if in_.returnn_data.have_batch_axis() and in_.returnn_data.batch_dim_axis in returnn_axes:
-      if set(in_.returnn_data.get_dynamic_axes()).intersection(returnn_axes):
-        # We merge batch with some other dynamic axis.
-        batch_major = returnn_axes[0] == in_.returnn_data.batch_dim_axis
-        returnn_axes.pop(in_.returnn_data.batch_dim_axis)
-        assert len(returnn_axes) == 1  # not implemented otherwise
-        return {
-          "class": "flatten_batch",
-          "from": cls._get_input_layer_name(input),
-          "axis": cls._get_input_axis_to_returnn(input, axis=in_.torch_axis_from_returnn_axis[returnn_axes[0]]),
-          "batch_major": batch_major}
 
     return {
       "class": "merge_dims", "from": cls._get_input_layer_name(input),

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1137,8 +1137,7 @@ def test_flatten_batch():
 
   rnd = numpy.random.RandomState(42)
   x = rnd.normal(0., 1., (n_batch, n_in, n_time)).astype("float32")
-  converter = verify_torch_and_convert_to_returnn(model_func, inputs=x)
-  assert converter.returnn_net_dict["Flatten"]["class"] == "flatten_batch", pformat(converter.returnn_net_dict)
+  verify_torch_and_convert_to_returnn(model_func, inputs=x)
 
 
 def test_reduce_sum():


### PR DESCRIPTION
As mentioned in #85, the `FlattenBatchLayer` should not be used in `MergeDims`.