### PR TITLE
Checks for non-deterministic modules

### DIFF
--- a/pytorch_to_returnn/converter/converter.py
+++ b/pytorch_to_returnn/converter/converter.py
@@ -168,10 +168,10 @@ class Converter:
         visited_entries.add(entry_)
         if not all(call_.module.module.is_deterministic for call_ in entry_.output_from_calls):
           non_deterministic_tensor_entries.append(entry_)
+          continue
         for call_ in entry_.output_from_calls:
-          for prev_entry_ in [pe for pe in call_.inputs_args if isinstance(pe, TensorEntry)]:
-            if prev_entry_ not in visited_entries:
-              entries_to_visit.append(prev_entry_)
+          for prev_entry_ in [pe for pe in call_.inputs_tensor_deps if pe not in visited_entries]:
+            entries_to_visit.append(prev_entry_)
 
       for entry in non_deterministic_tensor_entries:
         if not all(call_.module.module.is_deterministic for call_ in entry.output_from_calls):

--- a/pytorch_to_returnn/converter/converter.py
+++ b/pytorch_to_returnn/converter/converter.py
@@ -158,22 +158,21 @@ class Converter:
       for i, size in input.size_placeholder.items():
         d[size] = [self._inputs_np.shape[input.get_batch_axis(i)]] * n_batch  # not so relevant
     if out_entry:
-      visited_entries = set()
       non_deterministic_tensor_entries =  []
-
-      def _get_non_deterministic_tensor_entries(entry_: TensorEntry):
-        """
-        Go recursively through all tensor entries to find non deterministic ones
-        """
+      entries_to_visit = [out_entry]
+      visited_entries = set()
+      while entries_to_visit:
+        entry_ = entries_to_visit.pop(0)
+        if entry_ in visited_entries:
+          continue
+        visited_entries.add(entry_)
         if not all(call_.module.module.is_deterministic for call_ in entry_.output_from_calls):
           non_deterministic_tensor_entries.append(entry_)
         for call_ in entry_.output_from_calls:
           for prev_entry_ in [pe for pe in call_.inputs_args if isinstance(pe, TensorEntry)]:
-            if prev_entry_ != entry_ and prev_entry_ not in visited_entries:
-              visited_entries.add(prev_entry_)
-              _get_non_deterministic_tensor_entries(prev_entry_)
+            if prev_entry_ not in visited_entries:
+              entries_to_visit.append(prev_entry_)
 
-      _get_non_deterministic_tensor_entries(out_entry)
       for entry in non_deterministic_tensor_entries:
         if not all(call_.module.module.is_deterministic for call_ in entry.output_from_calls):
           assert entry.validated_to_torch_tf_feed_dict is not None

--- a/pytorch_to_returnn/converter/converter.py
+++ b/pytorch_to_returnn/converter/converter.py
@@ -170,8 +170,9 @@ class Converter:
           non_deterministic_tensor_entries.append(entry_)
           continue
         for call_ in entry_.output_from_calls:
-          for prev_entry_ in [pe for pe in call_.inputs_tensor_deps if pe not in visited_entries]:
-            entries_to_visit.append(prev_entry_)
+          for prev_entry_ in call_.inputs_tensor_deps:
+            if prev_entry_ not in visited_entries:
+              entries_to_visit.append(prev_entry_)
 
       for entry in non_deterministic_tensor_entries:
         if not all(call_.module.module.is_deterministic for call_ in entry.output_from_calls):

--- a/pytorch_to_returnn/converter/converter.py
+++ b/pytorch_to_returnn/converter/converter.py
@@ -320,6 +320,10 @@ class Converter:
       x = network.extern_data.get_default_input_data()
       y = network.get_default_output_layer().output
       feed_dict = self._make_tf_feed_dict(x)
+      naming = Naming.get_instance()
+      feed_dict.update({
+        network.layers[layer_name].output.placeholder: value for layer_name, value in
+        naming.non_deterministic_layer_outputs.items()})
       y_, y_size = session.run((y.placeholder, y.size_placeholder.as_dict()), feed_dict=feed_dict)
       assert isinstance(y_, numpy.ndarray)
       print("Output shape:", y_.shape)
@@ -361,6 +365,10 @@ class Converter:
       x = network.extern_data.get_default_input_data()
       y = network.get_default_output_layer().output
       feed_dict = self._make_tf_feed_dict(x)
+      naming = Naming.get_instance()
+      feed_dict.update({
+        network.layers[layer_name].output.placeholder: value for layer_name, value in
+        naming.non_deterministic_layer_outputs.items()})
       y_, y_size = session.run((y.placeholder, y.size_placeholder.as_dict()), feed_dict=feed_dict)
       assert isinstance(y_, numpy.ndarray)
       print("Output shape:", y_.shape)

--- a/pytorch_to_returnn/converter/converter.py
+++ b/pytorch_to_returnn/converter/converter.py
@@ -158,6 +158,8 @@ class Converter:
       for i, size in input.size_placeholder.items():
         d[size] = [self._inputs_np.shape[input.get_batch_axis(i)]] * n_batch  # not so relevant
     if out_entry:
+      visited_entries = set()
+
       def _get_non_deterministic_tensor_entries(entry_: TensorEntry):
         """
         Go recursively through all tensor entries to find non deterministic ones
@@ -167,7 +169,8 @@ class Converter:
         non_det_mods = []
         for call_ in entry_.output_from_calls:
           for prev_entry_ in [pe for pe in call_.inputs_args if isinstance(pe, TensorEntry)]:
-            if prev_entry_ != entry_:
+            if prev_entry_ != entry_ and prev_entry_ not in visited_entries:
+              visited_entries.add(prev_entry_)
               non_det_mods += _get_non_deterministic_tensor_entries(prev_entry_)
         return non_det_mods
 

--- a/pytorch_to_returnn/converter/converter.py
+++ b/pytorch_to_returnn/converter/converter.py
@@ -12,7 +12,7 @@ from returnn.tf.util.data import Data, Dim, batch_dim
 from pytorch_to_returnn import torch as torch_returnn
 from pytorch_to_returnn.import_wrapper import wrapped_import_torch_traced, wrapped_import_torch_returnn
 from pytorch_to_returnn.import_wrapper.torch_wrappers.tensor import WrappedTorchTensor
-from pytorch_to_returnn.naming import Naming
+from pytorch_to_returnn.naming import Naming, TensorEntry
 
 
 ModelFuncType = Callable[[Optional[Callable[[str], types.ModuleType]], torch.Tensor], torch.Tensor]
@@ -144,7 +144,7 @@ class Converter:
     assert self._returnn_net_dict, "Call run() first."
     return self._returnn_net_dict
 
-  def _make_tf_feed_dict(self, input: Data):
+  def _make_tf_feed_dict(self, input: Data, out_entry=None):
     assert input.batch_ndim == len(self._inputs_np.shape)
     assert all(input.batch_shape[i] in {None, self._inputs_np.shape[i]} for i in range(input.batch_ndim))
     n_batch = 1 if input.batch_dim_axis is None else self._inputs_np.shape[input.batch_dim_axis]
@@ -156,6 +156,14 @@ class Converter:
     else:
       for i, size in input.size_placeholder.items():
         d[size] = [self._inputs_np.shape[input.get_batch_axis(i)]] * n_batch  # not so relevant
+    if out_entry:
+      def _output_from_non_deterministic(tensor_entry_: TensorEntry):
+        return not all(call_.module.module.is_deterministic for call_ in tensor_entry_.output_from_calls)
+
+      for entry in [out_entry.output_from_calls[0].inputs_args[0]]:  # TODO: this is just the case I'm looking for right now, needs to be generalized
+        if _output_from_non_deterministic(entry):
+          assert entry.validated_to_torch_tf_feed_dict is not None
+          d.update(entry.validated_to_torch_tf_feed_dict)
     return d
 
   def _run_reference(self):
@@ -245,7 +253,7 @@ class Converter:
         print(">>>> Modules with params:")
         pprint(dict(torch_mods_with_params))
 
-      feed_dict = self._make_tf_feed_dict(x)
+      feed_dict = self._make_tf_feed_dict(x, out_returnn_)
       y_, y_size = session.run((y.placeholder, y.size_placeholder.as_dict()), feed_dict=feed_dict)
       assert isinstance(y_, numpy.ndarray)
       self._out_returnn_np = y_

--- a/pytorch_to_returnn/import_wrapper/context.py
+++ b/pytorch_to_returnn/import_wrapper/context.py
@@ -121,10 +121,16 @@ def make_torch_traced_ctx(wrapped_mod_prefix: str) -> WrapCtx:
     torch.nn.Module: ExplicitWrappedType(torch.nn.Module, WrappedModuleBase, wrap=_raise_not_implemented),
   }
 
-  class Functional(WrappedModuleBase):
-    pass
+  class Functional(torch.nn.Module):
+    def __init__(self, func, func_name):
+      super(Functional, self).__init__()
+      self.func = func
+      self.func_name = func_name
 
-  obj_map = {torch.randint: lambda func: Functional(func, "randint")}
+    def forward(self, *args, **kwargs):
+      return self.func(*args, **kwargs)
+
+  obj_map = {torch.randint: Functional(torch.randint, "randint")}
 
   return WrapCtx(
     wrapped_mod_prefix=wrapped_mod_prefix,

--- a/pytorch_to_returnn/import_wrapper/context.py
+++ b/pytorch_to_returnn/import_wrapper/context.py
@@ -130,7 +130,7 @@ def make_torch_traced_ctx(wrapped_mod_prefix: str) -> WrapCtx:
     def forward(self, *args, **kwargs):
       return self.func(*args, **kwargs)
 
-  obj_map = {torch.randint: Functional(torch.randint, "randint")}
+  obj_map = {torch.randint: (Functional, (torch.randint, "randint"))}
 
   return WrapCtx(
     wrapped_mod_prefix=wrapped_mod_prefix,

--- a/pytorch_to_returnn/import_wrapper/context.py
+++ b/pytorch_to_returnn/import_wrapper/context.py
@@ -98,7 +98,7 @@ def make_torch_traced_ctx(wrapped_mod_prefix: str) -> WrapCtx:
   which keep track of the tensors, and create names using the :class:`Naming` logic.
   """
   import torch
-  from .torch_wrappers import WrappedTorchTensor, WrappedTorchParameter, WrappedModuleBase, Functional
+  from .torch_wrappers import WrappedTorchTensor, WrappedTorchParameter, WrappedModuleBase, WrappedTorchFunction
 
   _KeepAsIsTypes = (
     torch.device,
@@ -124,7 +124,7 @@ def make_torch_traced_ctx(wrapped_mod_prefix: str) -> WrapCtx:
   from .base_wrappers import make_wrapped_function, make_wrapped_class
   def _make_wrapped_func(obj, ctx: WrapCtx, name: str):
     wrapped_func = make_wrapped_function(obj, name=name, ctx=ctx)
-    wrapped_class = make_wrapped_class(Functional, name="_.Functional", ctx=ctx)
+    wrapped_class = make_wrapped_class(WrappedTorchFunction, name="_.WrappedTorchFunction", ctx=ctx)
     return wrapped_class(func=wrapped_func, func_name=name)
 
   _ObjMap = {torch.randint: _make_wrapped_func}

--- a/pytorch_to_returnn/import_wrapper/context.py
+++ b/pytorch_to_returnn/import_wrapper/context.py
@@ -121,7 +121,7 @@ def make_torch_traced_ctx(wrapped_mod_prefix: str) -> WrapCtx:
     torch.nn.Module: ExplicitWrappedType(torch.nn.Module, WrappedModuleBase, wrap=_raise_not_implemented),
   }
 
-  class Functional(torch.nn.Module):
+  class Functional(WrappedModuleBase):
     def __init__(self, func, func_name):
       super(Functional, self).__init__()
       self.func = func
@@ -130,7 +130,11 @@ def make_torch_traced_ctx(wrapped_mod_prefix: str) -> WrapCtx:
     def forward(self, *args, **kwargs):
       return self.func(*args, **kwargs)
 
-  obj_map = {torch.randint: (Functional, (torch.randint, "randint"))}
+    @classmethod
+    def has_torch_forward(cls) -> bool:
+      return False
+
+  obj_map = {torch.randint: (Functional, (torch.randint, "RandInt"))}
 
   return WrapCtx(
     wrapped_mod_prefix=wrapped_mod_prefix,

--- a/pytorch_to_returnn/import_wrapper/context.py
+++ b/pytorch_to_returnn/import_wrapper/context.py
@@ -1,5 +1,5 @@
 
-from typing import Set, Iterable, Dict, Optional, Callable, TypeVar, Type
+from typing import Set, Iterable, Dict, Optional, Callable, TypeVar, Type, Any
 from .mod_map import ModMap
 
 
@@ -10,7 +10,7 @@ class WrapCtx:
                wrap_mods_alternatives: Dict[str, str] = None,
                keep_as_is_types: Iterable[type] = (),
                explicit_wrapped_types: Dict[type, "ExplicitWrappedType"] = None,
-               explicit_wrapped_objects: Dict[Callable, Callable] = None):
+               explicit_wrapped_objects: Dict[Any, Callable[[Any], Any]] = None):
     """
     :param wrapped_mod_prefix: e.g. "pytorch_to_returnn._wrapped_mods."
     :param wrap_mods_direct: e.g. {"torch.nn.modules"}

--- a/pytorch_to_returnn/import_wrapper/torch_wrappers/__init__.py
+++ b/pytorch_to_returnn/import_wrapper/torch_wrappers/__init__.py
@@ -2,4 +2,4 @@
 from .tensor import WrappedTorchTensor
 from .parameter import WrappedTorchParameter
 from .module import WrappedModuleBase
-from .function import Functional
+from .function import WrappedTorchFunction

--- a/pytorch_to_returnn/import_wrapper/torch_wrappers/__init__.py
+++ b/pytorch_to_returnn/import_wrapper/torch_wrappers/__init__.py
@@ -2,3 +2,4 @@
 from .tensor import WrappedTorchTensor
 from .parameter import WrappedTorchParameter
 from .module import WrappedModuleBase
+from .function import Functional

--- a/pytorch_to_returnn/import_wrapper/torch_wrappers/function.py
+++ b/pytorch_to_returnn/import_wrapper/torch_wrappers/function.py
@@ -1,9 +1,9 @@
 from .module import WrappedModuleBase
 
 
-class Functional(WrappedModuleBase):
+class WrappedTorchFunction(WrappedModuleBase):
   def __init__(self, func, func_name):
-    super(Functional, self).__init__()
+    super(WrappedTorchFunction, self).__init__()
     self.func = func
     self.func_name = func_name
 

--- a/pytorch_to_returnn/import_wrapper/torch_wrappers/function.py
+++ b/pytorch_to_returnn/import_wrapper/torch_wrappers/function.py
@@ -1,0 +1,17 @@
+from .module import WrappedModuleBase
+
+
+class Functional(WrappedModuleBase):
+  def __init__(self, func, func_name):
+    super(Functional, self).__init__()
+    self.func = func
+    self.func_name = func_name
+
+  def forward(self, *args, **kwargs):
+    return self.func(*args, **kwargs)
+
+  @classmethod
+  def has_torch_forward(cls) -> bool:
+    # has to be False, such that :func:`_flatten_namespace_for_mod` returns False in `make_module_call` and a
+    # corresponding entry in the namespace's `childs_by_name` is created which we need later on to find this module.
+    return False

--- a/pytorch_to_returnn/import_wrapper/wrap.py
+++ b/pytorch_to_returnn/import_wrapper/wrap.py
@@ -15,7 +15,7 @@ def wrap(obj, *, name: str, ctx: WrapCtx):
   if isinstance(obj, ctx.keep_as_is_types):
     return obj
   if obj in ctx.explicit_wrapped_objects:
-    obj = ctx.explicit_wrapped_objects[obj](obj)
+    obj = make_wrapped_object(ctx.explicit_wrapped_objects[obj], name=name, ctx=ctx)
   obj = _nested_transform(obj, lambda _x: wrap(_x, name="%s..." % name, ctx=ctx))
 
   if isinstance(obj, types.ModuleType):

--- a/pytorch_to_returnn/import_wrapper/wrap.py
+++ b/pytorch_to_returnn/import_wrapper/wrap.py
@@ -15,10 +15,8 @@ def wrap(obj, *, name: str, ctx: WrapCtx):
   if isinstance(obj, ctx.keep_as_is_types):
     return obj
   if isinstance(obj, Hashable) and obj in ctx.explicit_wrapped_objects:
-    func, args = ctx.explicit_wrapped_objects[obj]
-    args = [make_wrapped_function(arg, name=name, ctx=ctx) if isinstance(arg, _FuncTypes) else arg for arg in args]
-    wrapped_class = make_wrapped_class(func, name=name, ctx=ctx)
-    obj = wrapped_class(*args)
+    func = ctx.explicit_wrapped_objects[obj]
+    obj = func(obj, name=name, ctx=ctx)
   obj = _nested_transform(obj, lambda _x: wrap(_x, name="%s..." % name, ctx=ctx))
 
   if isinstance(obj, types.ModuleType):

--- a/pytorch_to_returnn/import_wrapper/wrap.py
+++ b/pytorch_to_returnn/import_wrapper/wrap.py
@@ -1,5 +1,5 @@
 
-from collections import OrderedDict, Counter
+from collections import OrderedDict, Counter, Hashable
 import types
 from typing import Tuple
 import importlib
@@ -14,8 +14,11 @@ def wrap(obj, *, name: str, ctx: WrapCtx):
     return obj
   if isinstance(obj, ctx.keep_as_is_types):
     return obj
-  if obj in ctx.explicit_wrapped_objects:
-    obj = make_wrapped_object(ctx.explicit_wrapped_objects[obj], name=name, ctx=ctx)
+  if isinstance(obj, Hashable) and obj in ctx.explicit_wrapped_objects:
+    func, args = ctx.explicit_wrapped_objects[obj]
+    args = [make_wrapped_function(arg, name=name, ctx=ctx) if isinstance(arg, _FuncTypes) else arg for arg in args]
+    wrapped_class = make_wrapped_class(func, name=name, ctx=ctx)
+    obj = wrapped_class(*args)
   obj = _nested_transform(obj, lambda _x: wrap(_x, name="%s..." % name, ctx=ctx))
 
   if isinstance(obj, types.ModuleType):

--- a/pytorch_to_returnn/import_wrapper/wrap.py
+++ b/pytorch_to_returnn/import_wrapper/wrap.py
@@ -14,6 +14,8 @@ def wrap(obj, *, name: str, ctx: WrapCtx):
     return obj
   if isinstance(obj, ctx.keep_as_is_types):
     return obj
+  if obj in ctx.explicit_wrapped_objects:
+    obj = ctx.explicit_wrapped_objects[obj](obj)
   obj = _nested_transform(obj, lambda _x: wrap(_x, name="%s..." % name, ctx=ctx))
 
   if isinstance(obj, types.ModuleType):

--- a/pytorch_to_returnn/naming/call.py
+++ b/pytorch_to_returnn/naming/call.py
@@ -171,9 +171,10 @@ class CallEntry:
           for tensor_returnn, tensor_torch in zip(self.outputs_flat, torch_mod_call.orig_outputs_flat):
             if tensor_returnn:
               tensor_returnn.validated_to_torch = True
+              if not tensor_returnn.validated_to_torch_tf_feed_dict:
+                tensor_returnn.validated_to_torch_tf_feed_dict = {}
               torch_np = tensor_torch.detach().cpu().numpy()
-              tensor_returnn.validated_to_torch_tf_feed_dict[
-              tensor_returnn.returnn_data.placeholder] = torch_np
+              tensor_returnn.validated_to_torch_tf_feed_dict[tensor_returnn.returnn_data.placeholder] = torch_np
         if not layer.get_absolute_name().startswith("."):  # temp layer
           if module.is_original_torch_module and not module.has_torch_forward():
             if list(module.parameters(recurse=False)):

--- a/pytorch_to_returnn/naming/call.py
+++ b/pytorch_to_returnn/naming/call.py
@@ -175,6 +175,7 @@ class CallEntry:
                 tensor_returnn.validated_to_torch_tf_feed_dict = {}
               torch_np = tensor_torch.detach().cpu().numpy()
               tensor_returnn.validated_to_torch_tf_feed_dict[tensor_returnn.returnn_data.placeholder] = torch_np
+              naming.non_deterministic_layer_outputs[layer.get_absolute_name()] = torch_np
         if not layer.get_absolute_name().startswith("."):  # temp layer
           if module.is_original_torch_module and not module.has_torch_forward():
             if list(module.parameters(recurse=False)):

--- a/pytorch_to_returnn/naming/call.py
+++ b/pytorch_to_returnn/naming/call.py
@@ -160,6 +160,20 @@ class CallEntry:
         f"[{','.join(layer.output.get_batch_axes_short_description())}]")
 
       if naming.import_params_from_torch_namespace and layer:
+        if not module.is_deterministic:
+          mod_abs_name = naming.get_module_abs_id_name(module)
+          torch_mod = naming.import_params_from_torch_namespace.get_module_by_abs_id_name(mod_abs_name)
+          torch_mod_calls = naming.import_params_from_torch_namespace.get_module_calls(torch_mod)
+          call_idx = naming.get_module_call_idx(module=module, call=self)
+          assert call_idx < len(torch_mod_calls)
+          torch_mod_call = torch_mod_calls[call_idx]
+          assert len(torch_mod_call.orig_outputs_flat) == len(self.outputs_flat)
+          for tensor_returnn, tensor_torch in zip(self.outputs_flat, torch_mod_call.orig_outputs_flat):
+            if tensor_returnn:
+              tensor_returnn.validated_to_torch = True
+              torch_np = tensor_torch.detach().cpu().numpy()
+              tensor_returnn.validated_to_torch_tf_feed_dict[
+              tensor_returnn.returnn_data.placeholder] = torch_np
         if not layer.get_absolute_name().startswith("."):  # temp layer
           if module.is_original_torch_module and not module.has_torch_forward():
             if list(module.parameters(recurse=False)):

--- a/pytorch_to_returnn/naming/naming.py
+++ b/pytorch_to_returnn/naming/naming.py
@@ -457,7 +457,7 @@ class Naming:
     """
     This is the inverse of :func:`get_module_abs_id_name`.
     """
-    from ..import_wrapper.torch_wrappers import Functional
+    from ..import_wrapper.torch_wrappers import WrappedTorchFunction
 
     potential_namespaces = [self.root_namespace]
     potential_modules = [m for m in self.root_namespace.modules]
@@ -470,10 +470,10 @@ class Naming:
           for name_ in potential_namespaces:
             if part_name in name_.childs_by_name:
               potential_namespaces_.append(name_.childs_by_name[part_name])
-            else:  # look for explicitly wrapped objects using :class:`Functional`
+            else:  # look for explicitly wrapped objects using :class:`WrappedTorchFunction`
               for child_ in name_.childs_by_name.values():
                 for mod_ in child_.modules:
-                  if isinstance(mod_.module, Functional) and part_name in mod_.module.func_name:
+                  if isinstance(mod_.module, WrappedTorchFunction) and part_name in mod_.module.func_name:
                     potential_namespaces_.append(child_)
           assert potential_namespaces_, (
             f"{potential_namespaces} have not {part_name!r}, after {'.'.join(name_parts[:i + 1])!r}")

--- a/pytorch_to_returnn/naming/naming.py
+++ b/pytorch_to_returnn/naming/naming.py
@@ -21,6 +21,7 @@ class Naming:
   modules: OrderedDict[_types.Module, _module.ModuleEntry]
   inputs: List[_tensor.TensorEntry]
   outputs: List[_tensor.TensorEntry]
+  non_deterministic_layer_outputs: Dict[str, numpy.ndarray] = {}
   module_creation_stack: List[_module.ModuleEntry]
   module_apply_stack: List[_module.ModuleEntry]
   module_context_stack: List[_module.ModuleEntry]

--- a/pytorch_to_returnn/naming/naming.py
+++ b/pytorch_to_returnn/naming/naming.py
@@ -21,7 +21,7 @@ class Naming:
   modules: OrderedDict[_types.Module, _module.ModuleEntry]
   inputs: List[_tensor.TensorEntry]
   outputs: List[_tensor.TensorEntry]
-  non_deterministic_layer_outputs: Dict[str, numpy.ndarray] = {}
+  non_deterministic_layer_outputs: Dict[str, numpy.ndarray]
   module_creation_stack: List[_module.ModuleEntry]
   module_apply_stack: List[_module.ModuleEntry]
   module_context_stack: List[_module.ModuleEntry]
@@ -76,6 +76,7 @@ class Naming:
     self.modules = OrderedDict()
     self.inputs = []
     self.outputs = []
+    self.non_deterministic_layer_outputs = {}
     self.module_context_stack = []
     self.module_creation_stack = []
     self.module_apply_stack = []

--- a/pytorch_to_returnn/naming/naming.py
+++ b/pytorch_to_returnn/naming/naming.py
@@ -462,10 +462,18 @@ class Naming:
       for i, part_name in enumerate(name_parts):
         if part_name[:1] == "(" and part_name[-1:] == ")":
           part_name = part_name[1:-1]
-          possible_namespaces = [name_ for name_ in potential_namespaces if part_name in name_.childs_by_name]
-          assert possible_namespaces, (
+          potential_namespaces_ = []
+          for name_ in potential_namespaces:
+            if part_name in name_.childs_by_name:
+              potential_namespaces_.append(name_.childs_by_name[part_name])
+            else:  # look for explicitly wrapped objects using :class:`Functional`
+              for child_ in name_.childs_by_name.values():
+                for mod_ in child_.modules:
+                  if part_name in getattr(mod_.module, "func_name", ""):
+                    potential_namespaces_.append(child_)
+          assert potential_namespaces_, (
             f"{potential_namespaces} have not {part_name!r}, after {'.'.join(name_parts[:i + 1])!r}")
-          potential_namespaces = [name_.childs_by_name[part_name] for name_ in potential_namespaces]
+          potential_namespaces = potential_namespaces_
           potential_modules = []
           for name_ in potential_namespaces:
             for m in name_.modules:

--- a/pytorch_to_returnn/naming/naming.py
+++ b/pytorch_to_returnn/naming/naming.py
@@ -458,7 +458,7 @@ class Naming:
     This is the inverse of :func:`get_module_abs_id_name`.
     """
     from ..import_wrapper.torch_wrappers import Functional
-    
+
     potential_namespaces = [self.root_namespace]
     potential_modules = [m for m in self.root_namespace.modules]
     if name:

--- a/pytorch_to_returnn/naming/naming.py
+++ b/pytorch_to_returnn/naming/naming.py
@@ -457,6 +457,8 @@ class Naming:
     """
     This is the inverse of :func:`get_module_abs_id_name`.
     """
+    from ..import_wrapper.torch_wrappers import Functional
+    
     potential_namespaces = [self.root_namespace]
     potential_modules = [m for m in self.root_namespace.modules]
     if name:
@@ -471,7 +473,7 @@ class Naming:
             else:  # look for explicitly wrapped objects using :class:`Functional`
               for child_ in name_.childs_by_name.values():
                 for mod_ in child_.modules:
-                  if part_name in getattr(mod_.module, "func_name", ""):
+                  if isinstance(mod_.module, Functional) and part_name in mod_.module.func_name:
                     potential_namespaces_.append(child_)
           assert potential_namespaces_, (
             f"{potential_namespaces} have not {part_name!r}, after {'.'.join(name_parts[:i + 1])!r}")

--- a/pytorch_to_returnn/torch/nn/functional.py
+++ b/pytorch_to_returnn/torch/nn/functional.py
@@ -93,6 +93,20 @@ def arange(*args, out: Optional[Tensor]=None, dtype: Optional[_dtype]=None, devi
   return mod(end, start, step, dtype, False)
 
 
+def randint(*args, dtype: Optional[_dtype]=None, **kwargs) -> Tensor:
+  low = kwargs.get("low", None)
+  high = kwargs.get("high", None)
+  size = kwargs.get("size", None)
+  if len(args) == 3:
+    low, high, size = args
+  elif len(args) == 2:
+    high, size = args
+    low = 0
+  assert None not in (low, high, size)
+  mod = modules.RandInt()
+  return mod(low, high, size, dtype)
+
+
 def tensor(data, *, dtype=None, device=None, requires_grad=False, pin_memory=False):
   from .._C import from_numpy
   x = from_numpy(data)

--- a/pytorch_to_returnn/torch/nn/modules/module.py
+++ b/pytorch_to_returnn/torch/nn/modules/module.py
@@ -54,6 +54,7 @@ class Module:
   # All derived classes here, which exist in PyTorch as well (e.g. torch.nn.Conv1d etc),
   # should have this set to True.
   is_original_torch_module: bool = True
+  is_deterministic: bool = True  # for non-deterministic modules, save output and add it to feed dict to stay comparable
   _forward_feed_dict_deps: bool = False  # for internal usage
 
   _wrapped_class_cache = {}  # cls -> WrappedClass

--- a/pytorch_to_returnn/torch/nn/modules/operator.py
+++ b/pytorch_to_returnn/torch/nn/modules/operator.py
@@ -72,6 +72,10 @@ class RandInt(Module):
     returnn_axis_from_torch_axis = {i: i for i in range(len(torch_shape))}
     return torch_shape, returnn_axis_from_torch_axis
 
+  def get_returnn_name(self) -> str:
+    # Used to allow finding this module in the namespace
+    return "randint"
+
 
 class Cat(Module):
   is_original_torch_module = False

--- a/pytorch_to_returnn/torch/nn/modules/operator.py
+++ b/pytorch_to_returnn/torch/nn/modules/operator.py
@@ -46,6 +46,33 @@ class Range(Module):
     return torch_shape, returnn_axis_from_torch_axis
 
 
+class RandInt(Module):
+  is_original_torch_module = False
+  is_deterministic = False
+
+  def create_returnn_layer_dict(self, low, high, size, dtype=None) -> Dict[str, Any]:
+    dtype = dtype or "int64"
+    assert isinstance(low, int)
+    assert isinstance(high, int)
+    assert all(isinstance(sz, int) for sz in size)
+    return {"class": "rand_int", "shape": size, "maxval": high, "minval": low, "dtype": dtype}
+
+  def _get_output_shape_from_returnn(self,
+                                     inputs_flat: List[Optional[Union[Tensor, int, bool]]], layer: LayerBase
+                                     ) -> Tuple[Tuple[int, ...], Dict[int, int]]:
+    _, _, *size, _ = inputs_flat
+
+    def _to_int(x: Union[Tensor, int]):
+      if isinstance(x, Tensor):
+        assert x.is_defined
+        x = x.numpy()
+      return x
+
+    torch_shape = tuple(_to_int(sz) for sz in size)
+    returnn_axis_from_torch_axis = {i: i for i in range(len(torch_shape))}
+    return torch_shape, returnn_axis_from_torch_axis
+
+
 class Cat(Module):
   is_original_torch_module = False
 

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -10,6 +10,24 @@ from pytorch_to_returnn.converter import verify_torch_and_convert_to_returnn
 from pytorch_to_returnn.pprint import pformat
 
 
+def test_randint():
+  n_batch, n_time, n_feat = 3, 5, 7
+
+  def model_func(wrapped_import, inputs: torch.Tensor):
+    if typing.TYPE_CHECKING or not wrapped_import:
+      import torch
+    else:
+      torch = wrapped_import("torch")
+    out = torch.randint(low=0, high=3, size=(6, 7))
+    out = out + 1
+    return out
+
+  rnd = numpy.random.RandomState(42)
+  x = rnd.normal(0., 1., (n_batch, n_time, n_feat)).astype("float32")
+  verify_torch_and_convert_to_returnn(model_func, inputs=x, inputs_data_kwargs={
+    "shape": (None, n_feat), "batch_dim_axis": 0, "time_dim_axis": 1, "feature_dim_axis": 2})
+
+
 def test_embedding():
   n_in, n_out = 11, 13
   n_batch, n_time = 3, 7


### PR DESCRIPTION
As described in #89, we currently do not account for non-deterministic modules when checking against the reference.

I would like to add `torch.randint`, therefore this PR should also introduce a logic for non-deterministic modules