### PR TITLE
add RETURNN behavior_version

### DIFF
--- a/pytorch_to_returnn/converter/converter.py
+++ b/pytorch_to_returnn/converter/converter.py
@@ -317,6 +317,7 @@ class Converter:
       config = Config({
         "extern_data": {"data": self._returnn_in_data_dict},
         "debug_print_layer_output_template": True,
+        "behavior_version": 12,
       })
       network = TFNetwork(config=config, name="root", train_flag=self.train)
       network.construct_from_dict(self._returnn_net_dict)
@@ -361,6 +362,7 @@ class Converter:
       config = Config({
         "extern_data": {"data": self._returnn_in_data_dict},
         "debug_print_layer_output_template": True,
+        "behavior_version": 12,
       })
       network = TFNetwork(config=config, name="root", train_flag=self.train)
       network.construct_from_dict(net_dict)

--- a/pytorch_to_returnn/converter/converter.py
+++ b/pytorch_to_returnn/converter/converter.py
@@ -13,6 +13,7 @@ from pytorch_to_returnn import torch as torch_returnn
 from pytorch_to_returnn.import_wrapper import wrapped_import_torch_traced, wrapped_import_torch_returnn
 from pytorch_to_returnn.import_wrapper.torch_wrappers.tensor import WrappedTorchTensor
 from pytorch_to_returnn.naming import Naming, TensorEntry
+from pytorch_to_returnn.naming.returnn_ctx import returnn_behavior_version
 
 
 ModelFuncType = Callable[[Optional[Callable[[str], types.ModuleType]], torch.Tensor], torch.Tensor]
@@ -317,7 +318,7 @@ class Converter:
       config = Config({
         "extern_data": {"data": self._returnn_in_data_dict},
         "debug_print_layer_output_template": True,
-        "behavior_version": 12,
+        "behavior_version": returnn_behavior_version,
       })
       network = TFNetwork(config=config, name="root", train_flag=self.train)
       network.construct_from_dict(self._returnn_net_dict)
@@ -362,7 +363,7 @@ class Converter:
       config = Config({
         "extern_data": {"data": self._returnn_in_data_dict},
         "debug_print_layer_output_template": True,
-        "behavior_version": 12,
+        "behavior_version": returnn_behavior_version,
       })
       network = TFNetwork(config=config, name="root", train_flag=self.train)
       network.construct_from_dict(net_dict)

--- a/pytorch_to_returnn/naming/returnn_ctx.py
+++ b/pytorch_to_returnn/naming/returnn_ctx.py
@@ -27,8 +27,11 @@ class ReturnnContext:
       self._dummy_sub_output = self.sub_net_layer.subnetwork.layers["output"]
     else:
       self.config = Config({
+        "behavior_version": 12,
         # "debug_print_layer_output_template": True,
       })
+      from returnn.util import BehaviorVersion
+      BehaviorVersion.set(self.config.int("behavior_version", None))
       self.tf_name_scope = ""
       self.sub_net_layer = None
       self._dummy_sub_output = None

--- a/pytorch_to_returnn/naming/returnn_ctx.py
+++ b/pytorch_to_returnn/naming/returnn_ctx.py
@@ -20,7 +20,8 @@ class ReturnnContext:
       self.sub_net_layer = parent.network.construct_layer(
         name=name,
         # This is just a placeholder, will be replaced in define_output.
-        net_dict={name: {"class": "subnetwork", "from": "data", "subnetwork": {"output": {"class": "copy"}}}})
+        net_dict={name: {"class": "subnetwork", "from": "data", "subnetwork": {
+          "output": {"class": "copy", "from": "data"}}}})
       assert isinstance(self.sub_net_layer, SubnetworkLayer)
       if name.startswith("."):  # temp sub net
         # We do not want that the parent net finds it.

--- a/pytorch_to_returnn/naming/returnn_ctx.py
+++ b/pytorch_to_returnn/naming/returnn_ctx.py
@@ -6,6 +6,8 @@ from returnn.tf.network import TFNetwork, ExternData
 from returnn.tf.layers.basic import LayerBase, SubnetworkLayer
 from . import tensor as _tensor
 
+returnn_behavior_version = 12
+
 
 class ReturnnContext:
   def __init__(self, *, parent: Optional[ReturnnContext] = None, name: Optional[str] = None, returnn_train_flag: bool):
@@ -27,7 +29,7 @@ class ReturnnContext:
       self._dummy_sub_output = self.sub_net_layer.subnetwork.layers["output"]
     else:
       self.config = Config({
-        "behavior_version": 12,
+        "behavior_version": returnn_behavior_version,
         # "debug_print_layer_output_template": True,
       })
       from returnn.util import BehaviorVersion

--- a/pytorch_to_returnn/naming/tensor.py
+++ b/pytorch_to_returnn/naming/tensor.py
@@ -103,19 +103,14 @@ class TensorEntry:
     if axis == self.returnn_data.feature_dim_axis:
       return "F"
     dim_tag = self.returnn_data.get_dim_tag(axis)
-    if dim_tag.dyn_size is not None:
-      axes_with_same_dim_tag = [ax for ax in range(ndim) if dim_tag == self.returnn_data.get_dim_tag(ax)]
-      if len(axes_with_same_dim_tag) == 1:
-        return f"stag:{dim_tag.description}"
-      else:
-        return f"stag-single:{axes_with_same_dim_tag.index(axis) - len(axes_with_same_dim_tag)}:{dim_tag.description}"
+    axes_with_same_dim_tag = [ax for ax in range(ndim) if dim_tag == self.returnn_data.get_dim_tag(ax)]
     static_axes = self.returnn_data.get_static_axes()
-    if axis in static_axes:
-      return f"static:{static_axes.index(axis)}"
-    spatial_axes = self.returnn_data.get_spatial_batch_axes()
-    if axis in spatial_axes:
-      return f"spatial:{spatial_axes.index(axis)}"
-    raise Exception(f"Should not get here. Dim tag {dim_tag} for axis {axis} for data {self.returnn_data}")
+    if len(axes_with_same_dim_tag) == 1:
+      return f"stag:{dim_tag.description}"
+    if axis in static_axes and len(static_axes) == 1:
+      return f"dim:{dim_tag.description}"
+    else:
+      return f"stag-single:{axes_with_same_dim_tag.index(axis) - len(axes_with_same_dim_tag)}:{dim_tag.description}"
 
   @property
   def torch_axis_from_returnn_axis(self) -> Dict[int, int]:

--- a/pytorch_to_returnn/torch/nn/modules/batchnorm.py
+++ b/pytorch_to_returnn/torch/nn/modules/batchnorm.py
@@ -96,7 +96,7 @@ class _BatchNorm(_NormBase):
     return {
       "class": "batch_norm", "from": self._get_input_layer_name(input),
       "update_sample_only_in_training": True, "delay_sample_update": True,
-      "param_version": 1, "masked_time": False,
+      "param_version": 2, "masked_time": False,
       "momentum": self.momentum, "epsilon": self.eps}
 
 

--- a/pytorch_to_returnn/torch/nn/modules/batchnorm.py
+++ b/pytorch_to_returnn/torch/nn/modules/batchnorm.py
@@ -96,7 +96,7 @@ class _BatchNorm(_NormBase):
     return {
       "class": "batch_norm", "from": self._get_input_layer_name(input),
       "update_sample_only_in_training": True, "delay_sample_update": True,
-      "param_version": 1,
+      "param_version": 1, "masked_time": True,
       "momentum": self.momentum, "epsilon": self.eps}
 
 

--- a/pytorch_to_returnn/torch/nn/modules/batchnorm.py
+++ b/pytorch_to_returnn/torch/nn/modules/batchnorm.py
@@ -96,7 +96,7 @@ class _BatchNorm(_NormBase):
     return {
       "class": "batch_norm", "from": self._get_input_layer_name(input),
       "update_sample_only_in_training": True, "delay_sample_update": True,
-      "param_version": 1, "masked_time": True,
+      "param_version": 1, "masked_time": False,
       "momentum": self.momentum, "epsilon": self.eps}
 
 

--- a/pytorch_to_returnn/torch/nn/modules/batchnorm.py
+++ b/pytorch_to_returnn/torch/nn/modules/batchnorm.py
@@ -111,16 +111,9 @@ class BatchNorm1d(_BatchNorm):
       assert len(ps) == 1, f"param name {name} not unique or found in layer {layer} with params {layer.params}"
       return ps[0]
 
-    def _expand_dims(x: numpy.ndarray) -> numpy.ndarray:
-      assert x.shape == (layer.output.dim,)
-      out_shape = [
-        layer.output.dim if i == layer.output.feature_dim_axis else 1
-        for i in range(layer.output.batch_ndim)]
-      return numpy.reshape(x, out_shape)
-
     def _convert(x: Tensor, name: str):
       tf_param = _get_param_by_name_postfix(name)
-      values = _expand_dims(x.detach().cpu().numpy())
+      values = x.detach().cpu().numpy()
       tf_param.load(values, session=session)
 
     _convert(torch_module.running_mean, "mean")

--- a/pytorch_to_returnn/torch/nn/modules/conv.py
+++ b/pytorch_to_returnn/torch/nn/modules/conv.py
@@ -84,7 +84,9 @@ class _ConvNd(Module):
       "with_bias": self.bias is not None,
       "n_out": self.out_channels,
       "filter_size": self.kernel_size,
-      "padding": "valid"}
+      "padding": "valid",
+      "in_spatial_dims": [self._get_input_axis_to_returnn(input, dim) for dim in range(-self.nd, 0)],
+    }
     if any(s != 1 for s in self.stride):
       d["strides"] = self.stride
     if any(d != 1 for d in self.dilation):
@@ -202,7 +204,9 @@ class _ConvTransposeNd(_ConvNd):
       "filter_size": self.kernel_size,
       "strides": self.stride,
       "padding": "valid",
-      "output_padding": self.output_padding}
+      "output_padding": self.output_padding,
+      "in_spatial_dims": [self._get_input_axis_to_returnn(input, dim) for dim in range(-self.nd, 0)],
+    }
     if self.padding:
       d["remove_padding"] = self.padding
     return d
@@ -326,7 +330,9 @@ class _FunctionalConvNd(Module):
         "padding": "valid",
         "output_padding": self.output_padding,
         "remove_padding": self.padding,
-        "strides": self.stride}
+        "strides": self.stride,
+        "in_spatial_dims": [self._get_input_axis_to_returnn(input, dim) for dim in range(-self.nd, 0)],
+      }
     else:
       assert all(p == 0 for p in self.padding)  # not implemented otherwise
       assert all(p == 0 for p in self.output_padding)  # not implemented otherwise
@@ -341,7 +347,9 @@ class _FunctionalConvNd(Module):
         "filter_perm": returnn_weight_transpose_perm,
         "padding": "valid",
         "strides": self.stride,
-        "dilation_rate": self.dilation}
+        "dilation_rate": self.dilation,
+        "in_spatial_dims": [self._get_input_axis_to_returnn(input, dim) for dim in range(-self.nd, 0)],
+      }
 
 
 class FunctionalConv1d(_FunctionalConvNd):

--- a/pytorch_to_returnn/torch/nn/modules/pooling.py
+++ b/pytorch_to_returnn/torch/nn/modules/pooling.py
@@ -32,7 +32,9 @@ class _MaxPoolNd(Module):
       "pool_size": self.kernel_size,
       "dilation_rate": self.dilation,
       "strides": self.stride,
-      "padding": "valid"}
+      "padding": "valid",
+      "in_spatial_dims": [self._get_input_axis_to_returnn(input, dim) for dim in range(-self.nd, 0)],
+    }
 
 
 class MaxPool1d(_MaxPoolNd):

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -805,7 +805,7 @@ def test_batch_norm_running_stats():
         assert len(module_entry.calls) == 1
         call = module_entry.calls[0]
         assert call.returnn_layer
-        mean_returnn = tf.squeeze(call.returnn_layer.params["batch_norm/mean"]).eval()
+        mean_returnn = tf.squeeze(call.returnn_layer.params["batch_norm/v2_mean"]).eval()
     model.reset_running_stats()  # for the test, such that we start with initial running mean/var
     return out
 


### PR DESCRIPTION
For #92, we need RETURNN's `behavior_version` to have the correct behavior of the `DotLayer`. There might be fixes necessary due to this change.