### PR TITLE
randint: allow dynamic inputs

### DIFF
--- a/pytorch_to_returnn/import_wrapper/context.py
+++ b/pytorch_to_returnn/import_wrapper/context.py
@@ -121,11 +121,14 @@ def make_torch_traced_ctx(wrapped_mod_prefix: str) -> WrapCtx:
     torch.nn.Module: ExplicitWrappedType(torch.nn.Module, WrappedModuleBase, wrap=_raise_not_implemented),
   }
 
-  from .base_wrappers import make_wrapped_function, make_wrapped_class
   def _make_wrapped_func(obj, ctx: WrapCtx, name: str):
-    wrapped_func = make_wrapped_function(obj, name=name, ctx=ctx)
-    wrapped_class = make_wrapped_class(WrappedTorchFunction, name="_.WrappedTorchFunction", ctx=ctx)
-    return wrapped_class(func=wrapped_func, func_name=name)
+    def _wrapped_func(*args, **kwargs):
+      from .base_wrappers import make_wrapped_function, make_wrapped_class
+      wrapped_func = make_wrapped_function(obj, name=name, ctx=ctx)
+      wrapped_class = make_wrapped_class(WrappedTorchFunction, name="_.WrappedTorchFunction", ctx=ctx)
+      wrapped_obj = wrapped_class(func=wrapped_func, func_name=name)
+      return wrapped_obj(*args, **kwargs)
+    return _wrapped_func
 
   _ObjMap = {torch.randint: _make_wrapped_func}
 

--- a/pytorch_to_returnn/import_wrapper/context.py
+++ b/pytorch_to_returnn/import_wrapper/context.py
@@ -122,10 +122,11 @@ def make_torch_traced_ctx(wrapped_mod_prefix: str) -> WrapCtx:
   }
 
   def _make_wrapped_func(obj, ctx: WrapCtx, name: str):
+    from .base_wrappers import make_wrapped_function, make_wrapped_class
+    wrapped_func = make_wrapped_function(obj, name=name, ctx=ctx)
+    wrapped_class = make_wrapped_class(WrappedTorchFunction, name="_.WrappedTorchFunction", ctx=ctx)
+
     def _wrapped_func(*args, **kwargs):
-      from .base_wrappers import make_wrapped_function, make_wrapped_class
-      wrapped_func = make_wrapped_function(obj, name=name, ctx=ctx)
-      wrapped_class = make_wrapped_class(WrappedTorchFunction, name="_.WrappedTorchFunction", ctx=ctx)
       wrapped_obj = wrapped_class(func=wrapped_func, func_name=name)
       return wrapped_obj(*args, **kwargs)
     return _wrapped_func

--- a/pytorch_to_returnn/naming/naming.py
+++ b/pytorch_to_returnn/naming/naming.py
@@ -473,8 +473,9 @@ class Naming:
             else:  # look for explicitly wrapped objects using :class:`WrappedTorchFunction`
               for child_ in name_.childs_by_name.values():
                 for mod_ in child_.modules:
-                  if isinstance(mod_.module, WrappedTorchFunction) and part_name in mod_.module.func_name:
-                    potential_namespaces_.append(child_)
+                  if isinstance(mod_.module, WrappedTorchFunction):
+                    if mod_.module.func_name.split(".")[-1] in part_name:
+                      potential_namespaces_.append(child_)
           assert potential_namespaces_, (
             f"{potential_namespaces} have not {part_name!r}, after {'.'.join(name_parts[:i + 1])!r}")
           potential_namespaces = potential_namespaces_

--- a/pytorch_to_returnn/naming/tensor.py
+++ b/pytorch_to_returnn/naming/tensor.py
@@ -12,7 +12,6 @@ from . import call as _call
 
 
 class TensorEntry:
-  # from ..torch._C import SizeValue
   tensor: ref[_types.Tensor]
   returnn_data: Optional[Data] = None
   returnn_axis_from_torch_axis: Optional[Dict[int, int]] = None

--- a/pytorch_to_returnn/naming/tensor.py
+++ b/pytorch_to_returnn/naming/tensor.py
@@ -12,6 +12,7 @@ from . import call as _call
 
 
 class TensorEntry:
+  # from ..torch._C import SizeValue
   tensor: ref[_types.Tensor]
   returnn_data: Optional[Data] = None
   returnn_axis_from_torch_axis: Optional[Dict[int, int]] = None
@@ -21,7 +22,7 @@ class TensorEntry:
   is_param: bool = False
   is_const: bool = False  # e.g. via from_numpy, empty, zeros, etc
   is_input: bool = False  # in TF1 terminology, would be a placeholder
-  is_dim: Optional[DimensionTag] = None
+  is_size_value: Optional[SizeValue] = None
   output_from_modules: List[_module.ModuleEntry]
   output_from_calls: List[_call.CallEntry]
   parent_owning_modules: List[Tuple[_module.ModuleEntry, str]]  # e.g. param or buffer

--- a/pytorch_to_returnn/torch/_C.py
+++ b/pytorch_to_returnn/torch/_C.py
@@ -178,7 +178,7 @@ class SizeValue(int):
     naming = Naming.get_instance()
     tensor_entry = naming.tensors[tensor]
     tensor_entry.is_const = True
-    tensor_entry.is_dim = self.dim_tag
+    tensor_entry.is_size_value = self
     return tensor
 
   def __repr__(self):

--- a/pytorch_to_returnn/torch/nn/modules/operator.py
+++ b/pytorch_to_returnn/torch/nn/modules/operator.py
@@ -52,9 +52,13 @@ class RandInt(Module):
 
   def create_returnn_layer_dict(self, low, high, size, dtype=None) -> Dict[str, Any]:
     dtype = dtype or "int64"
-    low = self._to_int(low)
-    high = self._to_int(high)
-    size = tuple(self._to_int(sz) for sz in size)
+    if isinstance(low, Tensor):
+      low = low.type(dtype)
+      low = self._get_input_layer_name(low)
+    if isinstance(high, Tensor):
+      high = high.type(dtype)
+      high = self._get_input_layer_name(high)
+    size = tuple(self._get_input_layer_name(sz) if isinstance(sz, Tensor) else sz for sz in size)
     return {"class": "rand_int", "shape": size, "maxval": high, "minval": low, "dtype": dtype}
 
   def _get_output_shape_from_returnn(self,

--- a/pytorch_to_returnn/torch/nn/modules/operator.py
+++ b/pytorch_to_returnn/torch/nn/modules/operator.py
@@ -70,7 +70,7 @@ class RandInt(Module):
         assert tensor_entry.is_size_value is not None
         for originating_tensor in tensor_entry.is_size_value.get_originating_tensors():
           if naming.tensors[originating_tensor] not in call.inputs_tensor_deps:
-            source.append(self._get_input_layer_name(tensor_entry.is_size_value.originating_tensor))
+            source.append(self._get_input_layer_name(originating_tensor))
             # add dependency to get complete in feed_dict in Module.make_output_tensor_from_returnn
             call.inputs_tensor_deps.append(naming.tensors[originating_tensor])
     size = tuple(naming.tensors[sz].is_size_value.dim_tag if isinstance(sz, Tensor) else sz for sz in size)

--- a/pytorch_to_returnn/torch/nn/modules/operator.py
+++ b/pytorch_to_returnn/torch/nn/modules/operator.py
@@ -68,9 +68,8 @@ class RandInt(Module):
       if isinstance(sz, Tensor):
         tensor_entry = naming.tensors[sz]
         assert tensor_entry.is_size_value is not None
-        originating_tensor = tensor_entry.is_size_value.originating_tensor
-        if originating_tensor is not None:
-          if originating_tensor not in call.inputs_tensor_deps:
+        for originating_tensor in tensor_entry.is_size_value.get_originating_tensors():
+          if naming.tensors[originating_tensor] not in call.inputs_tensor_deps:
             source.append(self._get_input_layer_name(tensor_entry.is_size_value.originating_tensor))
             # add dependency to get complete in feed_dict in Module.make_output_tensor_from_returnn
             call.inputs_tensor_deps.append(naming.tensors[originating_tensor])

--- a/pytorch_to_returnn/torch/nn/modules/shape.py
+++ b/pytorch_to_returnn/torch/nn/modules/shape.py
@@ -399,7 +399,7 @@ def _convert_dim_returnn(x: Union[SizeValue, int, Tensor]) -> Union[int, Dim]:
     return int(x)
   if isinstance(x, Tensor):
     tensor_entry = naming.tensors[x]
-    assert x.is_defined and tensor_entry.is_const and tensor_entry.is_size_value.dim_tag
+    assert x.is_defined and tensor_entry.is_const and tensor_entry.is_size_value and tensor_entry.is_size_value.dim_tag
     return tensor_entry.is_size_value.dim_tag
   raise TypeError(f"Convert dim to RETURNN: cannot handle dim {x!r} of type {type(x)}")
 

--- a/pytorch_to_returnn/torch/nn/modules/shape.py
+++ b/pytorch_to_returnn/torch/nn/modules/shape.py
@@ -399,8 +399,8 @@ def _convert_dim_returnn(x: Union[SizeValue, int, Tensor]) -> Union[int, Dim]:
     return int(x)
   if isinstance(x, Tensor):
     tensor_entry = naming.tensors[x]
-    assert x.is_defined and tensor_entry.is_const and tensor_entry.is_dim
-    return tensor_entry.is_dim
+    assert x.is_defined and tensor_entry.is_const and tensor_entry.is_size_value.dim_tag
+    return tensor_entry.is_size_value.dim_tag
   raise TypeError(f"Convert dim to RETURNN: cannot handle dim {x!r} of type {type(x)}")
 
 

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -28,6 +28,25 @@ def test_randint():
     "shape": (None, n_feat), "batch_dim_axis": 0, "time_dim_axis": 1, "feature_dim_axis": 2})
 
 
+def test_randint_dynamic():
+  n_batch, n_time, n_feat = 3, 5, 7
+
+  def model_func(wrapped_import, inputs: torch.Tensor):
+    if typing.TYPE_CHECKING or not wrapped_import:
+      import torch
+    else:
+      torch = wrapped_import("torch")
+    bsz, tsz, fsz = inputs.shape
+    out = torch.randint(low=0, high=tsz, size=(bsz, 3 * tsz))
+    out = out + 1
+    return out
+
+  rnd = numpy.random.RandomState(42)
+  x = rnd.normal(0., 1., (n_batch, n_time, n_feat)).astype("float32")
+  verify_torch_and_convert_to_returnn(model_func, inputs=x, inputs_data_kwargs={
+    "shape": (None, n_feat), "batch_dim_axis": 0, "time_dim_axis": 1, "feature_dim_axis": 2})
+
+
 def test_embedding():
   n_in, n_out = 11, 13
   n_batch, n_time = 3, 7


### PR DESCRIPTION
So far, we only supported `torch.randint` for integer inputs. In this PR, this should be extended to dynamic inputs.