### PR TITLE
fix Range._get_output_shape_from_returnn

### DIFF
--- a/pytorch_to_returnn/torch/nn/modules/operator.py
+++ b/pytorch_to_returnn/torch/nn/modules/operator.py
@@ -37,7 +37,7 @@ class Range(Module):
       assert limit.is_defined
       size = SizeValue((int(limit.numpy()) - int(start)) // int(delta))
       if limit.returnn_naming_entry.is_size_value is not None:
-        size.dim_tag = limit.returnn_naming_entry.is_size_value.dim_tag
+        size.dim_tag = (limit.returnn_naming_entry.is_size_value.dim_tag - int(start)) // int(delta)
         size.originating_tensor = limit.returnn_naming_entry.is_size_value.originating_tensor
     else:
       size = SizeValue((int(limit) - int(start)) // int(delta))

--- a/pytorch_to_returnn/torch/nn/modules/operator.py
+++ b/pytorch_to_returnn/torch/nn/modules/operator.py
@@ -33,14 +33,15 @@ class Range(Module):
                                      ) -> Tuple[Tuple[int, ...], Dict[int, int]]:
     from .shape import SizeValue
     limit, start, delta, *_ = inputs_flat
+    limit_size = None
     if isinstance(limit, Tensor):
       assert limit.is_defined
-      size = SizeValue((int(limit.numpy()) - int(start)) // int(delta))
-      if limit.returnn_naming_entry.is_size_value is not None:
-        size.dim_tag = (limit.returnn_naming_entry.is_size_value.dim_tag - int(start)) // int(delta)
-        size.originating_tensor = limit.returnn_naming_entry.is_size_value.originating_tensor
-    else:
-      size = SizeValue((int(limit) - int(start)) // int(delta))
+      limit_size = limit.returnn_naming_entry.is_size_value
+      limit = limit.numpy()
+    size = SizeValue((int(limit) - int(start)) // int(delta))
+    if limit_size is not None:
+      size.dim_tag = (limit_size.dim_tag - int(start)) // int(delta)
+      size.originating_tensor = limit_size.originating_tensor
     torch_shape = (size,)
     returnn_axis_from_torch_axis = {0: 0}
     return torch_shape, returnn_axis_from_torch_axis

--- a/pytorch_to_returnn/torch/nn/modules/operator.py
+++ b/pytorch_to_returnn/torch/nn/modules/operator.py
@@ -31,18 +31,16 @@ class Range(Module):
   def _get_output_shape_from_returnn(self,
                                      inputs_flat: List[Optional[Union[Tensor, int, bool]]], layer: LayerBase
                                      ) -> Tuple[Tuple[int, ...], Dict[int, int]]:
+    from .shape import SizeValue
     limit, start, delta, *_ = inputs_flat
-    limit_dim = None
     if isinstance(limit, Tensor):
       assert limit.is_defined
-      limit_dim = None
+      size = SizeValue((int(limit.numpy()) - int(start)) // int(delta))
       if limit.returnn_naming_entry.is_size_value is not None:
-        limit_dim = limit.returnn_naming_entry.is_size_value.dim_tag
-      limit = limit.numpy()
-    from .shape import SizeValue
-    size = SizeValue((int(limit) - int(start)) // int(delta))
-    if limit_dim:
-      size.dim_tag = (limit_dim - int(start)) // int(delta)
+        size.dim_tag = limit.returnn_naming_entry.is_size_value.dim_tag
+        size.originating_tensor = limit.returnn_naming_entry.is_size_value.originating_tensor
+    else:
+      size = SizeValue((int(limit) - int(start)) // int(delta))
     torch_shape = (size,)
     returnn_axis_from_torch_axis = {0: 0}
     return torch_shape, returnn_axis_from_torch_axis

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1395,6 +1395,23 @@ def test_arange_dyn():
   verify_torch_and_convert_to_returnn(model_func, inputs=x)
 
 
+def test_arange_dyn_unsqueeze():
+  n_batch, n_feat = 3, 5
+
+  def model_func(wrapped_import, inputs: torch.Tensor):
+    if typing.TYPE_CHECKING or not wrapped_import:
+      import torch
+    else:
+      torch = wrapped_import("torch")
+    arange = torch.arange(inputs.shape[0])
+    arange = arange.unsqueeze(1)
+    return arange
+
+  rnd = numpy.random.RandomState(42)
+  x = rnd.normal(0., 1., (n_batch, n_feat)).astype("float32")
+  verify_torch_and_convert_to_returnn(model_func, inputs=x)
+
+
 def test_arange_from_lengths():
   n_batch, n_time = 3, 5
 


### PR DESCRIPTION
In `Range._get_output_shape_from_returnn`, if `limit` is a `Tensor` we currently set the `dim_tag` for the `SizeValue` in `torch_shape`, but not the `originating_tensor`. This might be problematic as can be seen in the testcase that I added