### PR TITLE
Negative sampling demo

### DIFF
--- a/pytorch_to_returnn/torch/_C.py
+++ b/pytorch_to_returnn/torch/_C.py
@@ -207,6 +207,42 @@ class SizeValue(int):
     dim_tag = (other.dim_tag if isinstance(other, SizeValue) else other) * self.dim_tag
     return SizeValue(super(SizeValue, self).__rmul__(other), dim_tag=dim_tag, merged_dims=merged_dims)
 
+  def __add__(self, other):
+    assert isinstance(other, (int, SizeValue)), (  # could be allowed for static dims in the future
+      "Adding a SizeValue and an object of type {} is not allowed because it can lead to bugs, e.g. assumtion of a "
+      "static batch dim.".format(type(other)))
+    if type(other) == int and other == 0:
+      return self
+    dim_tag = self.dim_tag + (other.dim_tag if isinstance(other, SizeValue) else other)
+    return SizeValue(super(SizeValue, self).__add__(other), dim_tag=dim_tag)
+
+  def __radd__(self, other):
+    assert isinstance(other, (int, SizeValue)), (  # could be allowed for static dims in the future
+      "Adding a SizeValue and an object of type {} is not allowed because it can lead to bugs, e.g. assumtion of a "
+      "static batch dim.".format(type(other)))
+    if type(other) == int and other == 0:
+      return self
+    dim_tag = (other.dim_tag if isinstance(other, SizeValue) else other) + self.dim_tag
+    return SizeValue(super(SizeValue, self).__radd__(other), dim_tag=dim_tag)
+
+  def __sub__(self, other):
+    assert isinstance(other, (int, SizeValue)), (  # could be allowed for static dims in the future
+      "Subtracting a SizeValue and an object of type {} is not allowed because it can lead to bugs, e.g. assumtion of "
+      "a static batch dim.".format(type(other)))
+    if type(other) == int and other == 0:
+      return self
+    dim_tag = self.dim_tag - (other.dim_tag if isinstance(other, SizeValue) else other)
+    return SizeValue(super(SizeValue, self).__sub__(other), dim_tag=dim_tag)
+
+  def __floordiv__(self, other):
+    assert isinstance(other, (int, SizeValue)), (  # could be allowed for static dims in the future
+      "Floordiv of a SizeValue with object of type {} is not allowed because it can lead to bugs, e.g. assumtion of a "
+      "static batch dim.".format(type(other)))
+    if type(other) == int and other == 1:
+      return self
+    dim_tag = self.dim_tag // (other.dim_tag if isinstance(other, SizeValue) else other)
+    return SizeValue(super(SizeValue, self).__floordiv__(other), dim_tag=dim_tag)
+
 
 def zeros(*shape):
   from .tensor import Tensor

--- a/pytorch_to_returnn/torch/_C.py
+++ b/pytorch_to_returnn/torch/_C.py
@@ -129,11 +129,13 @@ class SizeValue(int):
   """
   We extend this, to store extra information, e.g. corresponding RETURNN dim tags.
   """
-  def __new__(cls, x: int, dim_tag: Optional[Dim] = None, merged_dims: Optional[List[SizeValue]] = None,
+  def __new__(cls, x: int, dim_tag: Optional[Dim] = None, derived_from_op: Optional[SizeValue.Op] = None,
               originating_tensor: Tensor = None):
     res = super(SizeValue, cls).__new__(cls, x)
     res.dim_tag = dim_tag or Dim(dimension=x, description="static_dim")
-    res.merged_dims = merged_dims or []
+    res.derived_from_op = derived_from_op
+    if derived_from_op and not derived_from_op.output:
+      derived_from_op.output = res
     res.originating_tensor = originating_tensor
     return res
 
@@ -154,18 +156,39 @@ class SizeValue(int):
   def get_originating_tensors(self) -> List[Tensor]:
     if self.originating_tensor is not None:
       return [self.originating_tensor]
-    if self.merged_dims:
+    if self.derived_from_op:
       return [
         d.originating_tensor
-        for d in self.merged_dims
+        for d in self.derived_from_op.inputs
         if isinstance(d, SizeValue) and d.originating_tensor is not None]
     return []
 
   def as_tensor(self):
-    if self.originating_tensor is None and self.merged_dims:
-      tensor = numpy.prod([
-        d.as_tensor() if isinstance(d, SizeValue) and d.dim_tag.dimension is None else int(d)
-        for d in self.merged_dims])
+    if self.originating_tensor is None and self.derived_from_op:
+      if self.derived_from_op.kind == "mul":
+        tensor = numpy.prod([
+          d.as_tensor() if isinstance(d, SizeValue) and d.dim_tag.dimension is None else int(d)
+          for d in self.derived_from_op.inputs])
+      elif self.derived_from_op.kind == "add":
+        tensor = numpy.sum([
+          d.as_tensor() if isinstance(d, SizeValue) and d.dim_tag.dimension is None else int(d)
+          for d in self.derived_from_op.inputs])
+      elif self.derived_from_op.kind == "sub":
+        assert len(self.derived_from_op.inputs) == 2
+        tensor = [
+          d.as_tensor() if isinstance(d, SizeValue) and d.dim_tag.dimension is None else int(d)
+          for d in self.derived_from_op.inputs]
+        tensor = tensor[0] - tensor[1]
+      elif self.derived_from_op.kind == "floordiv":
+        assert len(self.derived_from_op.inputs) == 2
+        tensor = [
+          d.as_tensor() if isinstance(d, SizeValue) and d.dim_tag.dimension is None else int(d)
+          for d in self.derived_from_op.inputs]
+        tensor = tensor[0] // tensor[1]
+      else:
+        raise ValueError(
+          "SizeValue.as_tensor() not implemented for SizeValue without originating tensor and "
+          "derived from op '{}'".format(self.derived_from_op.kind))
     else:
       assert self.originating_tensor is not None
       from .nn.modules import Length
@@ -187,15 +210,31 @@ class SizeValue(int):
       return f"?{res}"
     return f"{self.dim_tag.short_repr()}({res})"
 
+  class Op:
+    """
+    Op on :class:`SizeValue` which results in a derived :class:`SizeValue`.
+    """
+    def __init__(self, kind, inputs):
+      """
+      :param str kind: "add", "sub", "mul", "floordiv"
+      :param list[SizeValue] inputs:
+      """
+      self.kind = kind
+      self.inputs = inputs
+      self.output = None  # type: Optional[SizeValue]
+
+    def __repr__(self):
+      return "<SizeValue.Op %r %s>" % (self.kind, self.inputs)
+
   def __mul__(self, other):
     assert isinstance(other, (int, SizeValue)), (  # could be allowed for static dims in the future
       "Multiplying a SizeValue with object of type {} is not allowed because it can lead to bugs, e.g. assumtion of a "
       "static batch dim.".format(type(other)))
     if type(other) == int and other == 1:
       return self
-    merged_dims = [self, other]
+    derived_from_op = SizeValue.Op("mul", [self, other])
     dim_tag = self.dim_tag * (other.dim_tag if isinstance(other, SizeValue) else other)
-    return SizeValue(super(SizeValue, self).__mul__(other), dim_tag=dim_tag, merged_dims=merged_dims)
+    return SizeValue(super(SizeValue, self).__mul__(other), dim_tag=dim_tag, derived_from_op=derived_from_op)
 
   def __rmul__(self, other):
     assert isinstance(other, (int, SizeValue)), (  # could be allowed for static dims in the future
@@ -203,9 +242,9 @@ class SizeValue(int):
       "static batch dim.".format(type(other)))
     if type(other) == int and other == 1:
       return self
-    merged_dims = [other, self]
+    derived_from_op = SizeValue.Op("mul", [other, self])
     dim_tag = (other.dim_tag if isinstance(other, SizeValue) else other) * self.dim_tag
-    return SizeValue(super(SizeValue, self).__rmul__(other), dim_tag=dim_tag, merged_dims=merged_dims)
+    return SizeValue(super(SizeValue, self).__rmul__(other), dim_tag=dim_tag, derived_from_op=derived_from_op)
 
   def __add__(self, other):
     assert isinstance(other, (int, SizeValue)), (  # could be allowed for static dims in the future
@@ -213,8 +252,9 @@ class SizeValue(int):
       "static batch dim.".format(type(other)))
     if type(other) == int and other == 0:
       return self
+    derived_from_op = SizeValue.Op("add", [self, other])
     dim_tag = self.dim_tag + (other.dim_tag if isinstance(other, SizeValue) else other)
-    return SizeValue(super(SizeValue, self).__add__(other), dim_tag=dim_tag)
+    return SizeValue(super(SizeValue, self).__add__(other), dim_tag=dim_tag, derived_from_op=derived_from_op)
 
   def __radd__(self, other):
     assert isinstance(other, (int, SizeValue)), (  # could be allowed for static dims in the future
@@ -222,8 +262,9 @@ class SizeValue(int):
       "static batch dim.".format(type(other)))
     if type(other) == int and other == 0:
       return self
+    derived_from_op = SizeValue.Op("add", [other, self])
     dim_tag = (other.dim_tag if isinstance(other, SizeValue) else other) + self.dim_tag
-    return SizeValue(super(SizeValue, self).__radd__(other), dim_tag=dim_tag)
+    return SizeValue(super(SizeValue, self).__radd__(other), dim_tag=dim_tag, derived_from_op=derived_from_op)
 
   def __sub__(self, other):
     assert isinstance(other, (int, SizeValue)), (  # could be allowed for static dims in the future
@@ -231,8 +272,9 @@ class SizeValue(int):
       "a static batch dim.".format(type(other)))
     if type(other) == int and other == 0:
       return self
+    derived_from_op = SizeValue.Op("sub", [self, other])
     dim_tag = self.dim_tag - (other.dim_tag if isinstance(other, SizeValue) else other)
-    return SizeValue(super(SizeValue, self).__sub__(other), dim_tag=dim_tag)
+    return SizeValue(super(SizeValue, self).__sub__(other), dim_tag=dim_tag, derived_from_op=derived_from_op)
 
   def __floordiv__(self, other):
     assert isinstance(other, (int, SizeValue)), (  # could be allowed for static dims in the future
@@ -240,8 +282,9 @@ class SizeValue(int):
       "static batch dim.".format(type(other)))
     if type(other) == int and other == 1:
       return self
+    derived_from_op = SizeValue.Op("floordiv", [self, other])
     dim_tag = self.dim_tag // (other.dim_tag if isinstance(other, SizeValue) else other)
-    return SizeValue(super(SizeValue, self).__floordiv__(other), dim_tag=dim_tag)
+    return SizeValue(super(SizeValue, self).__floordiv__(other), dim_tag=dim_tag, derived_from_op=derived_from_op)
 
 
 def zeros(*shape):

--- a/pytorch_to_returnn/torch/nn/modules/operator.py
+++ b/pytorch_to_returnn/torch/nn/modules/operator.py
@@ -86,7 +86,7 @@ class RandInt(Module):
                                      ) -> Tuple[Tuple[int, ...], Dict[int, int]]:
     _, _, *size, _ = inputs_flat
 
-    torch_shape = tuple(self._to_int(sz) for sz in size)
+    torch_shape = tuple(self._to_size_value(sz) for sz in size)
     returnn_axis_from_torch_axis = {i: i for i in range(len(torch_shape))}
     return torch_shape, returnn_axis_from_torch_axis
 
@@ -95,12 +95,17 @@ class RandInt(Module):
     return "randint"
 
   @staticmethod
-  def _to_int(x: Union[Tensor, int]) -> int:
+  def _to_size_value(x: Union[int, Tensor]) -> SizeValue:
+    x_size = None
     if isinstance(x, Tensor):
       assert x.is_defined
-      x = int(x.numpy())
-    assert isinstance(x, int)
-    return x
+      x_size = x.returnn_naming_entry.is_size_value
+      x = x.numpy()
+    sv = SizeValue(int(x))
+    if x_size is not None:
+      sv.dim_tag = x_size.dim_tag
+      sv.originating_tensor = x_size.originating_tensor
+    return sv
 
 
 class Cat(Module):

--- a/pytorch_to_returnn/torch/nn/modules/operator.py
+++ b/pytorch_to_returnn/torch/nn/modules/operator.py
@@ -34,11 +34,15 @@ class Range(Module):
                                      ) -> Tuple[Tuple[int, ...], Dict[int, int]]:
     from .shape import SizeValue
     limit, start, delta, *_ = inputs_flat
+    size = None
     if isinstance(limit, Tensor):
       assert limit.is_defined
       limit_size = limit.returnn_naming_entry.is_size_value
-      size = (limit_size - int(start)) // int(delta)
-    else:
+      if limit_size is not None:
+        size = (limit_size - int(start)) // int(delta)
+      else:
+        limit = limit.numpy()
+    if size is None:
       size = SizeValue((int(limit) - int(start)) // int(delta))
     torch_shape = (size,)
     returnn_axis_from_torch_axis = {0: 0}

--- a/pytorch_to_returnn/torch/nn/modules/operator.py
+++ b/pytorch_to_returnn/torch/nn/modules/operator.py
@@ -34,18 +34,12 @@ class Range(Module):
                                      ) -> Tuple[Tuple[int, ...], Dict[int, int]]:
     from .shape import SizeValue
     limit, start, delta, *_ = inputs_flat
-    limit_size = None
     if isinstance(limit, Tensor):
       assert limit.is_defined
       limit_size = limit.returnn_naming_entry.is_size_value
-      limit = limit.numpy()
-    size = SizeValue((int(limit) - int(start)) // int(delta))
-    if limit_size is not None:
-      size.originating_tensor = limit_size.originating_tensor
-      size.dim_tag = limit_size.dim_tag - int(start)
-      size.derived_from_op = SizeValue.Op("add", [limit_size, int(start)])
-      size.dim_tag = size.dim_tag // int(delta)
-      size.derived_from_op = SizeValue.Op("floordiv", [size, int(delta)])
+      size = (limit_size - int(start)) // int(delta)
+    else:
+      size = SizeValue((int(limit) - int(start)) // int(delta))
     torch_shape = (size,)
     returnn_axis_from_torch_axis = {0: 0}
     return torch_shape, returnn_axis_from_torch_axis

--- a/pytorch_to_returnn/torch/nn/modules/operator.py
+++ b/pytorch_to_returnn/torch/nn/modules/operator.py
@@ -3,6 +3,7 @@ from typing import Optional, Tuple, Any, List, Dict, Set, Union
 from returnn.tf.layers.basic import LayerBase
 from returnn.tf.util.data import Dim
 from .module import Module
+from .shape import SizeValue
 from ...tensor import Tensor, dtype as _dtype
 from ....naming import Naming, TensorEntry
 
@@ -40,8 +41,11 @@ class Range(Module):
       limit = limit.numpy()
     size = SizeValue((int(limit) - int(start)) // int(delta))
     if limit_size is not None:
-      size.dim_tag = (limit_size.dim_tag - int(start)) // int(delta)
       size.originating_tensor = limit_size.originating_tensor
+      size.dim_tag = limit_size.dim_tag - int(start)
+      size.derived_from_op = SizeValue.Op("add", [limit_size, int(start)])
+      size.dim_tag = size.dim_tag // int(delta)
+      size.derived_from_op = SizeValue.Op("floordiv", [size, int(delta)])
     torch_shape = (size,)
     returnn_axis_from_torch_axis = {0: 0}
     return torch_shape, returnn_axis_from_torch_axis

--- a/pytorch_to_returnn/torch/nn/modules/shape.py
+++ b/pytorch_to_returnn/torch/nn/modules/shape.py
@@ -355,8 +355,7 @@ class FlattenBatch(Module):
     if self._seq_lens is not None:
       merged_dim = SizeValue(sum(self._seq_lens))
     else:
-      merged_dim = SizeValue(x.shape[batch_dim_idx[0]] * x.shape[merge_dim_idx[0]])
-    merged_dim.merged_dims = dims_to_merge
+      merged_dim = x.shape[batch_dim_idx[0]] * x.shape[merge_dim_idx[0]]
     torch_shape = (merged_dim,) + tuple(
       dim for i, dim in enumerate(x.shape) if i not in x_entry.returnn_data.get_axes_from_description("BT"))
     returnn_axis_from_torch_axis = {i: i for i in range(len(torch_shape))}
@@ -378,8 +377,8 @@ class UnflattenBatch(Module):
                                      ) -> Tuple[Tuple[int, ...], Dict[int, int]]:
     assert len(inputs_flat) == 1
     x = inputs_flat[0]
-    assert x.shape[0].merged_dims
-    torch_shape = tuple(x.shape[0].merged_dims) + x.shape[1:]
+    assert x.shape[0].derived_from_op and x.shape[0].derived_from_op.kind == "mul"
+    torch_shape = tuple(x.shape[0].derived_from_op.inputs) + x.shape[1:]
     returnn_axis_from_torch_axis = {i: i for i in range(len(torch_shape))}
     if self.batch_first != torch_shape[0].is_batch_dim:
       torch_shape = (torch_shape[1], torch_shape[0]) + torch_shape[2:]

--- a/pytorch_to_returnn/torch/nn/modules/shape.py
+++ b/pytorch_to_returnn/torch/nn/modules/shape.py
@@ -242,14 +242,13 @@ class Unflatten(Module):
     """
     naming = Naming.get_instance()
     x, = inputs_flat
-    unflattened_size = self.unflattened_size
+    unflatten_size = self.unflattened_size
     x_entry = naming.register_tensor(x)
     dim = self.dim
     assert -len(x.shape) <= dim < len(x.shape)
     if dim < 0:
       dim += len(x.shape)
     assert 0 <= dim < len(x.shape)
-    unflatten_size = [_convert_dim_torch(d) for d in unflattened_size]
     if any(d == -1 for d in unflatten_size):
       rem_dim = x.shape[dim]
       for d in unflatten_size:
@@ -401,15 +400,6 @@ def _convert_dim_returnn(x: Union[SizeValue, int, Tensor]) -> Union[int, Dim]:
     assert x.is_defined and tensor_entry.is_const and tensor_entry.is_size_value and tensor_entry.is_size_value.dim_tag
     return tensor_entry.is_size_value.dim_tag
   raise TypeError(f"Convert dim to RETURNN: cannot handle dim {x!r} of type {type(x)}")
-
-
-def _convert_dim_torch(x: Union[SizeValue, int, Tensor]) -> Union[int, SizeValue]:
-  if isinstance(x, int):
-    return int(x)
-  if isinstance(x, Tensor):
-    assert x.is_defined and x.shape == () and x.dtype.name.startswith("int")
-    return int(x.numpy())
-  raise TypeError(f"Convert dim to Torch: invalid dim {x!r} type {type(x)}")
 
 
 __all__ = [

--- a/pytorch_to_returnn/torch/nn/modules/variable.py
+++ b/pytorch_to_returnn/torch/nn/modules/variable.py
@@ -128,7 +128,6 @@ class FullStatic(Module):
       "value": self.fill_value, "dtype": self.dtype.name}
 
   def make_output_tensor_from_returnn(self, inputs_flat: List[Tensor], layer: LayerBase) -> Tensor:
-    from .shape import _convert_dim_torch
     naming = Naming.get_instance()
     size = [_convert_dim_torch(x) for x in inputs_flat]
     from ..._C import from_numpy
@@ -138,6 +137,15 @@ class FullStatic(Module):
     entry.returnn_data = layer.output
     entry.returnn_axis_from_torch_axis = {i: i for i in range(tensor.ndim)}
     return tensor
+
+
+def _convert_dim_torch(x: Union[SizeValue, int, Tensor]) -> Union[int, SizeValue]:
+  if isinstance(x, int):
+    return int(x)
+  if isinstance(x, Tensor):
+    assert x.is_defined and x.shape == () and x.dtype.name.startswith("int")
+    return int(x.numpy())
+  raise TypeError(f"Convert dim to Torch: invalid dim {x!r} type {type(x)}")
 
 
 __all__ = [

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -200,7 +200,7 @@ def test_cat_non_feature():
     else:
       import torch
 
-    x = inputs.expand(1, n_batch, n_feat, n_time)
+    x = inputs.expand(2, n_batch, n_feat, n_time)
     y = inputs.expand(3, n_batch, n_feat, n_time)
     return torch.cat([x, y], dim=0)
 

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -69,7 +69,7 @@ def test_negative_sampling():
     negs = negs.view(bsz, tsz, n_negatives, fsz).permute(2, 0, 1, 3)  # to (N,B,T,F)
     inputs = inputs.unsqueeze(0)  # (1,B,T,F)
     targets = torch.cat([inputs, negs], dim=0)  #(N+1,B,T,F)
-    return negs
+    return targets
 
   rnd = numpy.random.RandomState(42)
   x = rnd.normal(0., 1., (n_batch, n_time, n_feat)).astype("float32")


### PR DESCRIPTION
I added a testcase for negative sampling. Currently, there is an issue in the final concatenation (`torch.cat`) of the input with the negative samples. Namely, in `ConcatLayer`'s `_copy_compatible`, an additional axis is created which should not be the case and that results in an error. The problem, however, may already be in `torch.randint` where the RETURNN output is `(B,F)` although it is created with `(B,T)` dim tags.

I'll post the stack trace once the CI tests are finished.