### PR TITLE
Broadcasting for cosine similarity in negative sampling

### DIFF
--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -67,9 +67,10 @@ def test_negative_sampling():
     y = inputs.view(-1, fsz)  # (B,T,F) => (B*T,F)
     negs = y[neg_idxs.view(-1)]  # (B*T*N,F)
     negs = negs.view(bsz, tsz, n_negatives, fsz).permute(2, 0, 1, 3)  # to (N,B,T,F)
-    inputs = inputs.unsqueeze(0)  # (1,B,T,F)
-    targets = torch.cat([inputs, negs], dim=0)  #(N+1,B,T,F)
-    return targets
+    inputs_unsqueeze = inputs.unsqueeze(0)  # (1,B,T,F)
+    targets = torch.cat([inputs_unsqueeze, negs], dim=0)  # (N+1,B,T,F)
+    logits = torch.cosine_similarity(inputs.float(), targets.float(), dim=-1).type_as(inputs)
+    return logits
 
   rnd = numpy.random.RandomState(42)
   x = rnd.normal(0., 1., (n_batch, n_time, n_feat)).astype("float32")


### PR DESCRIPTION
In a contrastive loss, there is typically a cosine similarity applied after negative sampling. I added this to the test case that already exists, but currently this doesn't work yet because our `torch.cosine_similarity` doesn't support broadcasting. I added it in a commit here. `Dot._get_output_shape_from_returnn` is similar to `Matmul._get_output_shape_from_returnn`.

Then, there is some other issue inside `torch.cosine_similarity` which is also related to the broadcasting in this case and needs to be fixed. I'll describe it below.