### PR TITLE
fix serialization for SizeValues

### DIFF
--- a/pytorch_to_returnn/converter/converter.py
+++ b/pytorch_to_returnn/converter/converter.py
@@ -159,6 +159,7 @@ class Converter:
     config = dim_tags_proxy.collect_dim_tags_and_transform_config(config)
 
     code_lines = [
+      "import numpy\n",
       "from returnn.tf.util.data import Dim, batch_dim, single_step_dim, SpatialDim, FeatureDim\n\n",
       "use_tensorflow = True\n",
       f"behavior_version = {returnn_behavior_version}\n\n",

--- a/pytorch_to_returnn/converter/utils.py
+++ b/pytorch_to_returnn/converter/utils.py
@@ -1,6 +1,6 @@
 from typing import Optional, Dict, Tuple, Any, Sequence
 from returnn.tf.util.data import Dim, batch_dim, single_step_dim
-from ..torch._C import Size
+from ..torch._C import Size, SizeValue
 
 
 class ReturnnDimTagsProxy:
@@ -151,6 +151,8 @@ class ReturnnDimTagsProxy:
 
     # Cannot use nest because nest does not support sets. Also nest requires them to be sorted.
     def _map(path, value):
+      if isinstance(value, SizeValue):
+        return int(value)
       if isinstance(value, Dim):
         if value in {batch_dim, single_step_dim}:
           # No need to register this.

--- a/pytorch_to_returnn/converter/utils.py
+++ b/pytorch_to_returnn/converter/utils.py
@@ -97,16 +97,19 @@ class ReturnnDimTagsProxy:
       assert dim.can_be_used_as_dim()
       assert not dim.derived_from_op
       assert not dim.match_priority
+      dimension = dim.dimension
+      if isinstance(dimension, SizeValue):
+        dimension = int(dimension)
       # We assume FeatureDim, SpatialDim and Dim are imported.
       if dim.kind == Dim.Types.Feature:
-        return f"FeatureDim({dim.description!r}, {dim.dimension})"
+        return f"FeatureDim({dim.description!r}, {dimension})"
       if dim.kind == Dim.Types.Spatial:
-        if dim.dimension is not None:
-          return f"SpatialDim({dim.description!r}, {dim.dimension})"
+        if dimension is not None:
+          return f"SpatialDim({dim.description!r}, {dimension})"
         else:
           return f"SpatialDim({dim.description!r})"
       # generic fallback
-      return f"Dim(kind={dim.kind}, description={dim.description!r}, dimension={dim.dimension})"
+      return f"Dim(kind={dim.kind}, description={dim.description!r}, dimension={dimension})"
 
   class SetProxy:
     """

--- a/tests/returnn_helpers.py
+++ b/tests/returnn_helpers.py
@@ -1,0 +1,106 @@
+"""
+Helpers for RETURNN
+"""
+
+from __future__ import annotations
+from typing import Dict, Tuple, Any
+import returnn.tf.engine
+import returnn.datasets
+
+
+def dummy_run_net(config: Dict[str, Any], *, train: bool = False):
+  """
+  Runs a couple of training iterations using some dummy dataset on the net dict.
+  Use this to validate that the net dict is sane.
+  Note that this is somewhat slow. The whole TF session setup and net construction can take 5-30 secs or so.
+  It is not recommended to use this for every single test case.
+
+  The dummy dataset might change at some point...
+
+  Maybe this gets extended...
+  """
+  from returnn.tf.engine import Engine
+  from returnn.datasets import init_dataset
+  from returnn.config import Config
+  extern_data_opts = config["extern_data"]
+  n_data_dim = extern_data_opts["data"]["dim_tags"][-1].dimension
+  n_classes_dim = extern_data_opts["classes"]["sparse_dim"].dimension if "classes" in extern_data_opts else 7
+  config = Config({
+    "train": {
+      "class": "DummyDataset", "input_dim": n_data_dim, "output_dim": n_classes_dim,
+      "num_seqs": 2, "seq_len": 5},
+    "debug_print_layer_output_template": True,
+    "task": "train",  # anyway, to random init the net
+    **config
+  })
+  dataset = init_dataset(config.typed_value("train"))
+  engine = Engine(config=config)
+  engine.init_train_from_config(train_data=dataset)
+  if train:
+    engine.train()
+  else:
+    _dummy_forward_net_returnn(engine=engine, dataset=dataset)
+  return engine
+
+
+def _dummy_forward_net_returnn(*, engine: returnn.tf.engine.Engine, dataset: returnn.datasets.Dataset):
+  from returnn.tf.engine import Runner
+
+  def _extra_fetches_cb(*_args, **_kwargs):
+    pass  # just ignore
+
+  output = engine.network.get_default_output_layer().output
+  batches = dataset.generate_batches(
+    recurrent_net=engine.network.recurrent,
+    batch_size=engine.batch_size,
+    max_seqs=engine.max_seqs,
+    used_data_keys=engine.network.get_used_data_keys())
+  extra_fetches = {
+    'output': output.placeholder,
+    "seq_tag": engine.network.get_seq_tags(),
+  }
+  for i, seq_len in output.size_placeholder.items():
+    extra_fetches["seq_len_%i" % i] = seq_len
+  forwarder = Runner(
+    engine=engine, dataset=dataset, batches=batches,
+    train=False, eval=False,
+    extra_fetches=extra_fetches,
+    extra_fetches_callback=_extra_fetches_cb)
+  forwarder.run(report_prefix=engine.get_epoch_str() + " forward")
+
+
+# def dummy_config_net_dict(net: nn.Module, *,
+#                           with_axis=False, in_dim: int = 13
+#                           ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+#   """
+#   :return: config, net_dict
+#   """
+#   with nn.NameCtx.new_root() as name_ctx:
+#     time_dim = nn.SpatialDim("time")
+#     in_dim = nn.FeatureDim("input", in_dim)
+#     data = nn.get_extern_data(nn.Data("data", dim_tags=[nn.batch_dim, time_dim, in_dim]))
+#     opts = {}
+#     if with_axis:
+#       opts["axis"] = time_dim
+#     out = net(data, **opts, name=name_ctx)
+#     if isinstance(out, tuple):
+#       out = out[0]
+#     assert isinstance(out, nn.Tensor)
+#     out.mark_as_default_output()
+#
+#   config_code = name_ctx.get_returnn_config_serialized()
+#   return config_net_dict_via_serialized(config_code)
+
+
+def config_net_dict_via_serialized(config_code: str) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+  """
+  :param str config_code: via get_returnn_config_serialized
+  """
+  print(config_code)
+  scope = {}
+  exec(config_code, scope, scope)
+  for tmp in ["__builtins__", "Dim", "batch_dim", "FeatureDim", "SpatialDim"]:
+    scope.pop(tmp)
+  config = scope
+  net_dict = config["network"]
+  return config, net_dict

--- a/tests/returnn_helpers.py
+++ b/tests/returnn_helpers.py
@@ -1,5 +1,5 @@
 """
-Helpers for RETURNN
+Helpers for RETURNN, copied from returnn_common
 """
 
 from __future__ import annotations
@@ -67,29 +67,6 @@ def _dummy_forward_net_returnn(*, engine: returnn.tf.engine.Engine, dataset: ret
     extra_fetches=extra_fetches,
     extra_fetches_callback=_extra_fetches_cb)
   forwarder.run(report_prefix=engine.get_epoch_str() + " forward")
-
-
-# def dummy_config_net_dict(net: nn.Module, *,
-#                           with_axis=False, in_dim: int = 13
-#                           ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-#   """
-#   :return: config, net_dict
-#   """
-#   with nn.NameCtx.new_root() as name_ctx:
-#     time_dim = nn.SpatialDim("time")
-#     in_dim = nn.FeatureDim("input", in_dim)
-#     data = nn.get_extern_data(nn.Data("data", dim_tags=[nn.batch_dim, time_dim, in_dim]))
-#     opts = {}
-#     if with_axis:
-#       opts["axis"] = time_dim
-#     out = net(data, **opts, name=name_ctx)
-#     if isinstance(out, tuple):
-#       out = out[0]
-#     assert isinstance(out, nn.Tensor)
-#     out.mark_as_default_output()
-#
-#   config_code = name_ctx.get_returnn_config_serialized()
-#   return config_net_dict_via_serialized(config_code)
 
 
 def config_net_dict_via_serialized(config_code: str) -> Tuple[Dict[str, Any], Dict[str, Any]]:

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1787,7 +1787,9 @@ def test_returnn_config_serialization():
 
   cfg = converter.get_returnn_config_serialized()
   print(f"Serialized config:\n\n{cfg}")
-  exec(cfg)
+  from returnn_helpers import config_net_dict_via_serialized, dummy_run_net
+  config, net_dict = config_net_dict_via_serialized(cfg)
+  dummy_run_net(config)
 
 
 if __name__ == "__main__":

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1771,19 +1771,20 @@ def test_dummy_input_shape():
 
 
 def test_returnn_config_serialization():
-  n_batch, n_feat = 1, 5
+  n_batch, n_time, n_feat = 1, 5, 7
 
   def model_func(wrapped_import, inputs: torch.Tensor):
     if typing.TYPE_CHECKING or not wrapped_import:
       import torch
     else:
       torch = wrapped_import("torch")
-    arange = torch.arange(inputs.shape[1])
-    return inputs + torch.reshape(arange, (1, -1))
+    arange = torch.arange(inputs.shape[2])
+    return inputs + torch.reshape(arange, (1, 1, -1))
 
   rnd = numpy.random.RandomState(42)
-  x = rnd.normal(0., 1., (n_batch, n_feat)).astype("float32")
-  converter = verify_torch_and_convert_to_returnn(model_func, inputs=x)
+  x = rnd.normal(0., 1., (n_batch, n_time, n_feat)).astype("float32")
+  converter = verify_torch_and_convert_to_returnn(model_func, inputs=x, inputs_data_kwargs={
+    "shape": (None, n_feat), "batch_dim_axis": 0, "time_dim_axis": 1, "feature_dim_axis": 2})
 
   cfg = converter.get_returnn_config_serialized()
   print(f"Serialized config:\n\n{cfg}")

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1770,6 +1770,26 @@ def test_dummy_input_shape():
   verify_torch_and_convert_to_returnn(model_func, inputs=x, returnn_dummy_input_shape=x.shape)
 
 
+def test_returnn_config_serialization():
+  n_batch, n_feat = 1, 5
+
+  def model_func(wrapped_import, inputs: torch.Tensor):
+    if typing.TYPE_CHECKING or not wrapped_import:
+      import torch
+    else:
+      torch = wrapped_import("torch")
+    arange = torch.arange(inputs.shape[1])
+    return inputs + torch.reshape(arange, (1, -1))
+
+  rnd = numpy.random.RandomState(42)
+  x = rnd.normal(0., 1., (n_batch, n_feat)).astype("float32")
+  converter = verify_torch_and_convert_to_returnn(model_func, inputs=x)
+
+  cfg = converter.get_returnn_config_serialized()
+  print(f"Serialized config:\n\n{cfg}")
+  exec(cfg)
+
+
 if __name__ == "__main__":
   if len(sys.argv) <= 1:
     for k, v in sorted(globals().items()):


### PR DESCRIPTION
The serialization should get the `int` value of a `SizeValue`, otherwise we'll have something in the output network like `'shape': ('static_dim'(768)(768),)` which will obviously lead to an error.