### PR TITLE
Add cross entropy

### DIFF
--- a/pytorch_to_returnn/converter/converter.py
+++ b/pytorch_to_returnn/converter/converter.py
@@ -294,6 +294,8 @@ class Converter:
 
       feed_dict = self._make_tf_feed_dict(x, out_returnn_)
       y_, y_size = session.run((y.placeholder, y.size_placeholder.as_dict()), feed_dict=feed_dict)
+      if isinstance(y_, (numpy.float32, numpy.float64, numpy.int32, numpy.int64)):
+        y_ = numpy.array(y_)
       assert isinstance(y_, numpy.ndarray)
       self._out_returnn_np = y_
       print("Output shape:", y_.shape)
@@ -354,6 +356,8 @@ class Converter:
         network.layers[layer_name].output.placeholder: value for layer_name, value in
         self._non_deterministic_layer_outputs.items()})
       y_, y_size = session.run((y.placeholder, y.size_placeholder.as_dict()), feed_dict=feed_dict)
+      if isinstance(y_, (numpy.float32, numpy.float64, numpy.int32, numpy.int64)):
+        y_ = numpy.array(y_)
       assert isinstance(y_, numpy.ndarray)
       print("Output shape:", y_.shape)
       numpy.testing.assert_allclose(self._out_returnn_np, y_)
@@ -399,6 +403,8 @@ class Converter:
         network.layers[layer_name].output.placeholder: value for layer_name, value in
         self._non_deterministic_layer_outputs.items()})
       y_, y_size = session.run((y.placeholder, y.size_placeholder.as_dict()), feed_dict=feed_dict)
+      if isinstance(y_, (numpy.float32, numpy.float64, numpy.int32, numpy.int64)):
+        y_ = numpy.array(y_)
       assert isinstance(y_, numpy.ndarray)
       print("Output shape:", y_.shape)
       numpy.testing.assert_allclose(self._out_returnn_np, y_)

--- a/pytorch_to_returnn/torch/__init__.py
+++ b/pytorch_to_returnn/torch/__init__.py
@@ -11,3 +11,12 @@ from . import jit
 
 __version__ = "1.8.1"
 __returnn__ = True
+
+int = dtype("int32")
+int32 = dtype("int32")
+long = dtype("int64")
+int64 = dtype("int64")
+float = dtype("float32")
+float32 = dtype("float32")
+double = dtype("float64")
+float64 = dtype("float64")

--- a/pytorch_to_returnn/torch/nn/functional.py
+++ b/pytorch_to_returnn/torch/nn/functional.py
@@ -825,6 +825,30 @@ def cosine_similarity(x1: Tensor, x2: Tensor, dim: int=1, eps: float=1e-8) -> Te
   return numerator * inv_denominator
 
 
+def cross_entropy(
+  input: Tensor, target: Tensor, weight: Optional[Tensor] = None, size_average: Optional[bool] = None,
+  ignore_index: int = -100, reduce: Optional[bool] = None, reduction: str = "mean", label_smoothing: float = 0.0,
+) -> Tensor:
+  assert weight is None, "not implemented otherwise"
+  assert size_average is None, "not implemented otherwise"
+  assert ignore_index == -100, "not implemented otherwise"
+  assert reduce is None, "not implemented otherwise"
+  assert reduction == "sum", "not implemented otherwise"
+  assert label_smoothing == 0.0, "not implemented otherwise"
+
+  assert target.ndim == 1, "not implemented otherwise"
+  assert input.shape[0] == target.shape[0]
+
+  idcs = target + torch.arange(target.shape[0]) * target.shape[0]
+  input = input.t().exp()
+  num = input.flatten()[idcs]
+  denom = input.sum(dim=0)
+  ce = torch.log(num / denom) * -1
+  if reduction == "sum":
+    ce = ce.sum()
+  return ce
+
+
 def mse_loss():
   raise NotImplementedError
 

--- a/pytorch_to_returnn/torch/nn/functional.py
+++ b/pytorch_to_returnn/torch/nn/functional.py
@@ -523,6 +523,10 @@ def logsigmoid(input: Tensor):
   return modules.LogSigmoid().as_returnn_torch_functional()(input)
 
 
+def exp(input: Tensor):
+  return modules.Exp().as_returnn_torch_functional()(input)
+
+
 def pow(input: Tensor, exponent: float):
   return modules.Power(exponent=exponent).as_returnn_torch_functional()(input)
 
@@ -830,10 +834,6 @@ def ceil():
 
 
 def clamp():
-  raise NotImplementedError
-
-
-def exp():
   raise NotImplementedError
 
 

--- a/pytorch_to_returnn/torch/nn/modules/activation.py
+++ b/pytorch_to_returnn/torch/nn/modules/activation.py
@@ -56,6 +56,10 @@ class LogSigmoid(_ActivationReturnn):
   func_name = "log_sigmoid"
 
 
+class Exp(_ActivationReturnn):
+  func_name = "exp"
+
+
 class Power(Module):
   is_original_torch_module = False
 

--- a/pytorch_to_returnn/torch/tensor.py
+++ b/pytorch_to_returnn/torch/tensor.py
@@ -238,6 +238,10 @@ class Tensor:
     from .nn.functional import sigmoid
     return sigmoid(self)
 
+  def exp(self):
+    from .nn.functional import exp
+    return exp(self)
+
   def pow(self, exponent: float):
     from .nn.functional import pow
     return pow(self, exponent)

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1100,6 +1100,25 @@ def test_cosine_similarity():
     "shape": (None, n_feat), "batch_dim_axis": 0, "time_dim_axis": 1, "feature_dim_axis": 2})
 
 
+def test_cross_entropy():
+  n_batch, n_feat = 3, 7
+
+  def model_func(wrapped_import, inputs: torch.Tensor):
+    if wrapped_import:
+      torch = wrapped_import("torch")
+    else:
+      import torch
+
+    target = torch.randint(low=0, high=inputs.shape[0], size=(inputs.shape[0],))
+    ref = torch.nn.functional.cross_entropy(inputs, target, reduction="sum")
+    return ref
+
+  rnd = numpy.random.RandomState(42)
+  x = rnd.normal(0., 1., (n_batch, n_feat)).astype("float32")
+  verify_torch_and_convert_to_returnn(model_func, inputs=x, inputs_data_kwargs={
+    "shape": (n_feat,), "batch_dim_axis": 0, "feature_dim_axis": 1, "time_dim_axis": None})
+
+
 def test_unsqueeze():
   n_in, n_out = 11, 13
   n_batch, n_time = 3, 7


### PR DESCRIPTION
I added `torch.nn.functional.cross_entropy` and some small things that were necessary for that. It is used in the contrastive loss of wav2vec. I added an analogous usage in `test_contrastive_loss` which is not yet working fully.