### PR TITLE
allow functional depthwise conv

### DIFF
--- a/pytorch_to_returnn/torch/nn/modules/conv.py
+++ b/pytorch_to_returnn/torch/nn/modules/conv.py
@@ -314,7 +314,8 @@ class _FunctionalConvNd(Module):
     returnn_weight_transpose_perm = {i: j for (i, j) in zip(returnn_weight_axes, returnn_weight_axes_)}
     if bias is not None:
       assert bias.shape == (out_channels,)
-    assert self.groups == 1  # not implemented otherwise
+    if self.transposed:
+      assert self.groups == 1  # not implemented otherwise
     assert self.padding_mode == "zeros"  # not implemented otherwise
     if self.transposed:  # transposed conv
       assert all(d == 1 for d in self.dilation)
@@ -348,6 +349,7 @@ class _FunctionalConvNd(Module):
         "padding": "valid",
         "strides": self.stride,
         "dilation_rate": self.dilation,
+        "groups": self.groups,
         "in_spatial_dims": [self._get_input_axis_to_returnn(input, dim) for dim in range(-self.nd, 0)],
       }
 

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -762,6 +762,31 @@ def test_functional_conv():
   verify_torch_and_convert_to_returnn(model_func, inputs=x)
 
 
+def test_functional_depthwise_conv():
+  n_in, n_out = 12, 12
+  n_batch, n_time = 3, 7
+  kernel_size = 3
+  groups = n_in
+
+  def model_func(wrapped_import, inputs: torch.Tensor):
+    if typing.TYPE_CHECKING or not wrapped_import:
+      import torch
+      import torch.nn.functional as F
+    else:
+      torch = wrapped_import("torch")
+      F = wrapped_import("torch.nn.functional")
+    rnd = numpy.random.RandomState(42)
+    weight = rnd.normal(0., 1., (n_out, n_in // groups, kernel_size)).astype("float32")
+    bias = rnd.normal(0., 1., (n_out,)).astype("float32")
+    weight = torch.from_numpy(weight)
+    bias = torch.from_numpy(bias)
+    return F.conv1d(inputs, weight=weight, bias=bias, stride=2, groups=groups)
+
+  rnd = numpy.random.RandomState(42)
+  x = rnd.normal(0., 1., (n_batch, n_in, n_time)).astype("float32")
+  verify_torch_and_convert_to_returnn(model_func, inputs=x)
+
+
 def test_functional_conv_no_bias():
   n_in, n_out = 11, 13
   n_batch, n_time = 3, 7


### PR DESCRIPTION
Allow using groups for `_FunctionalConvNd`. I also added a test for depthwise convolution with stride 2. This revealed some problems on RETURNN side. It should work with https://github.com/rwth-i6/returnn/pull/1227.