### PR TITLE
allow custom modules with custom RETURNN layer

### DIFF
--- a/pytorch_to_returnn/torch/nn/modules/module.py
+++ b/pytorch_to_returnn/torch/nn/modules/module.py
@@ -515,6 +515,19 @@ class Module:
       return True  # always assume that the user module has custom forward code, even if not cls.forward
     return cls.forward is not Module.forward
 
+  @classmethod
+  def direct_returnn_layer_call(cls) -> bool:
+    """
+    Return True for modules which should be directly mapped to a RETURNN layer call. Otherwise, we assume that the
+    module has custom forward code which will then be mapped to RETURNN layer calls on that level.
+    """
+    if not cls.has_torch_forward():
+      return True
+    for base in cls.__bases__:
+      if hasattr(base, "create_returnn_layer_dict") and cls.create_returnn_layer_dict == base.create_returnn_layer_dict:
+        return False
+    return True
+
   def check_returnn_layer(self, layer: LayerBase):
     """
     You can override this function to perform extra checks on the constructed RETURNN layer,


### PR DESCRIPTION
I'd like to create a module which has a torch forward function, but nevertheless is mapped to a custom RETURNN layer call. The basic idea is to have something like
```
class MyModule(torch.nn.Module):
  is_original_torch_module = False

  def forward(self, x):
    y = foo(x)
    return y

  def create_returnn_layer_dict(self, input):
    return {"class": "<some_layer>", "from": self._get_input_layer_name(input)}
```

Right now, the custom `create_returnn_layer_dict` is ignored and the code inside `forward` is wrapped. This PR changes this behavior to make sure to use the custom `create_returnn_layer_dict`.